### PR TITLE
(bugfix) - Add volume parameter for Debian9 and Ubuntu16/18

### DIFF
--- a/tasks/docker.rb
+++ b/tasks/docker.rb
@@ -91,7 +91,14 @@ def provision(docker_platform, inventory_location)
     break unless stdout.include?(ports)
     raise 'All front facing ports are in use.' if front_facing_port == 2230
   end
-  creation_command = "docker run -d -it --privileged -p #{front_facing_port}:22 --name #{full_container_name} #{docker_platform}"
+  # setting volume parameter for debian9 and ubuntu16/18
+  os_string = docker_platform.split('/').last
+  if os_string == 'debian9' || os_string == 'ubuntu16.04' || os_string == 'ubuntu18.04'
+    deb_family_systemd_volume = '--volume /sys/fs/cgroup:/sys/fs/cgroup:ro'
+  else
+    deb_family_systemd_volume = ""
+  end
+  creation_command = "docker run -d -it #{deb_family_systemd_volume} --privileged -p #{front_facing_port}:22 --name #{full_container_name} #{docker_platform}"
   run_local_command(creation_command)
   install_ssh_components(platform, full_container_name)
   fix_ssh(platform, full_container_name)

--- a/tasks/docker.rb
+++ b/tasks/docker.rb
@@ -91,13 +91,11 @@ def provision(docker_platform, inventory_location)
     break unless stdout.include?(ports)
     raise 'All front facing ports are in use.' if front_facing_port == 2230
   end
-  # setting volume parameter for debian9 and ubuntu16/18
-  os_string = docker_platform.split('/').last
-  if os_string == 'debian9' || os_string == 'ubuntu16.04' || os_string == 'ubuntu18.04'
-    deb_family_systemd_volume = '--volume /sys/fs/cgroup:/sys/fs/cgroup:ro'
-  else
-    deb_family_systemd_volume = ""
-  end
+  deb_family_systemd_volume = if (docker_platform =~ %r{debian|ubuntu}) && (docker_platform !~ %r{debian8|ubuntu14})
+                                '--volume /sys/fs/cgroup:/sys/fs/cgroup:ro'
+                              else
+                                ''
+                              end
   creation_command = "docker run -d -it #{deb_family_systemd_volume} --privileged -p #{front_facing_port}:22 --name #{full_container_name} #{docker_platform}"
   run_local_command(creation_command)
   install_ssh_components(platform, full_container_name)


### PR DESCRIPTION
When provisioning Debian9 and Ubuntu16/18 you need to pass in ```--volume
/sys/fs/cgroup:/sys/fs/cgroup:ro``` to the command to provision.

This has been tested on the following to ensure breakages haven't been introduced.
- Ubuntu14

```➜  puppetlabs-mysql git:(litmus_conversion) ✗ bundle exec ruby spec/fixtures/modules/provision/tasks/docker.rb
{ "platform": "waffleimage/ubuntu14.04", "action": "provision", "inventory": "/Users/paula/workspace/puppetlabs-mysql" }
!!! Using private port forwarding!!!
docker run -d -it  --privileged -p 2225:22 --name waffleimage_ubuntu14.04_-2225 waffleimage/ubuntu14.04 
{"status":"ok","node_name":"localhost:2225"} 
```

- Ubuntu16
```➜ puppetlabs-mysql git:(litmus_conversion) ✗ bundle exec ruby spec/fixtures/modules/provision/tasks/docker.rb
{ "platform": "waffleimage/ubuntu16.04", "action": "provision", "inventory": "/Users/paula/workspace/puppetlabs-mysql" }
!!! Using private port forwarding!!!
docker run -d -it --volume /sys/fs/cgroup:/sys/fs/cgroup:ro --privileged -p 2224:22 --name waffleimage_ubuntu16.04_-2224 waffleimage/ubuntu16.04
{"status":"ok","node_name":"localhost:2224"}
```

- Ubuntu18
```➜  puppetlabs-mysql git:(litmus_conversion) ✗ bundle exec ruby spec/fixtures/modules/provision/tasks/docker.rb
{ "platform": "waffleimage/ubuntu18.04", "action": "provision", "inventory": "/Users/paula/workspace/puppetlabs-mysql" }
!!! Using private port forwarding!!!
docker run -d -it --volume /sys/fs/cgroup:/sys/fs/cgroup:ro --privileged -p 2223:22 --name waffleimage_ubuntu18.04_-2223 waffleimage/ubuntu18.04
{"status":"ok","node_name":"localhost:2223"}
```

- Debian9 
``` ➜  puppetlabs-mysql git:(litmus_conversion) ✗ bundle exec ruby spec/fixtures/modules/provision/tasks/docker.rb
{ "platform": "waffleimage/debian9", "action": "provision", "inventory": "/Users/paula/workspace/puppetlabs-mysql" }
!!! Using private port forwarding!!!
docker run -d -it --volume /sys/fs/cgroup:/sys/fs/cgroup:ro --privileged -p 2230:22 --name waffleimage_debian9_-2230 waffleimage/debian9
{"status":"ok","node_name":"localhost:2230"}
```