### PR TITLE
(FM-8178) Add Hyper-V Vagrant Support

### DIFF
--- a/README.md
+++ b/README.md
@@ -179,6 +179,40 @@ Successful on 1 node: localhost
 Ran on 1 node in 4.52 seconds
 ```
 
+#### Hyper-V Provider
+
+This task can also be used against a Windows host to utilize Hyper-V Vagrant boxes.
+When provisioning, a few additional parameters need to be passed:
+
+- `hyperv_vswitch`, which specifies the Hyper-V Virtual Switch to assign the VM.
+  If you do not specify one the [`Default Switch`](https://searchenterprisedesktop.techtarget.com/blog/Windows-Enterprise-Desktop/Default-Switch-Makes-Hyper-V-Networking-Dead-Simple) will be used.
+- `hyperv_smb_username` and `hyperv_smb_password`, which ensure the synced folder works correctly.
+  If these parameters are omitted when provisioning on Windows Vagrant will try to prompt for input and the task will hang indefinitely until it finally times out.
+  The context in which a Bolt task is run does not allow for mid-task input.
+
+Instead of passing them as parameters directly they can also be passed as environment variables:
+
+- `LITMUS_HYPERV_VSWITCH` for `hyperv_vswitch`
+- `HYPERV_SMB_USERNAME` for `hyperv_smb_username`
+- `HYPERV_SMB_PASSWORD` for `hyperv_smb_password`
+
+provision
+```
+PS> $env:LITMUS_HYPERV_VSWITCH = 'internal_nat'
+PS> bundle exec bolt --modulepath /Users/tp/workspace/git/ task run provision::vagrant --nodes localhost  action=provision platform=centos/7 inventory=/Users/tp/workspace/git/provision hyperv_smb_username=tp hyperv_smb_password=notMyrealPassword
+
+Started on localhost...
+Finished on localhost:
+  {
+    "status": "ok",
+    "node_name": "127.0.0.1:2222"
+  }
+Successful on 1 node: localhost
+Ran on 1 node in 51.98 seconds
+```
+
+Using the `tear_down` task is the same as on Linux or MacOS.
+
 ### Vmpooler
 
 Check http://vcloud.delivery.puppetlabs.net/vm/ for the list of availible platforms. 

--- a/tasks/vagrant.json
+++ b/tasks/vagrant.json
@@ -19,6 +19,20 @@
     "platform": {
       "description": "Platform to provision, eg  ubuntu:14.04",
       "type": "Optional[String[1]]"
+    },
+    "hyperv_vswitch": {
+      "description": "The Hyper-V virtual switch to spin the vagrant image up on",
+      "type": "Optional[String[1]]",
+      "default": "Default Switch"
+    },
+    "hyperv_smb_username": {
+      "description": "The username on the Hyper-V machine to use for authenticating the shared folder. Required to use Hyper-V.",
+      "type": "Optional[String[1]]"
+    },
+    "hyperv_smb_password": {
+      "description": "The password on the Hyper-V machine to use for authenticating the shared folder. Required to use Hyper-V.",
+      "type": "Optional[String[1]]",
+      "sensitive": true
     }
   },
   "files": [


### PR DESCRIPTION
This commit adds support to the Vagrant provisioner for
using the Hyper-V provider on windows. Right now it does
not do a smart determination of provider - if Windows,
use Hyper-V, else use VirtualBox.

It also adds three new parameters:

- `hyperv_vswitch` to specify which virtual switch the
  VM should be attached to. Note that if this is not
  specified it will attempt to use the `Default Switch`
  which is present on all Windows 10 (v1709+) machines.
- `hyperv_smb_username` and `hyperv_smb_password` which
  are required to automatically share the folder with
  the VM.

Without specifying both the switch and the SMB username
and password the task would fail as it cannot accept
any input in the context in which `bolt task run` has
to execute.

This commit updates the task, metadata, and documentation.