### PR TITLE
(FM-8274) Ensure vagrant task can provision Windows targets

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -11,3 +11,15 @@ group :development do
   gem "puppet-module-win-dev-r#{minor_version}",       require: false, platforms: %i[mswin mingw x64_mingw]
   gem 'github_changelog_generator',                    require: false, git: 'https://github.com/skywinder/github-changelog-generator', ref: '20ee04ba1234e9e83eb2ffb5056e23d641c7a018' if Gem::Version.new(RUBY_VERSION.dup) >= Gem::Version.new('2.2.2')
 end
+
+# Evaluate Gemfile.local and ~/.gemfile if they exist
+extra_gemfiles = [
+  "#{__FILE__}.local",
+  File.join(Dir.home, '.gemfile'),
+]
+
+extra_gemfiles.each do |gemfile|
+  if File.file?(gemfile) && File.readable?(gemfile)
+    eval(File.read(gemfile), binding)
+  end
+end

--- a/lib/task_helper.rb
+++ b/lib/task_helper.rb
@@ -32,6 +32,16 @@ def platform_is_windows?(platform)
   platform =~ windows_regex
 end
 
+def on_windows?
+  # Stolen directly from Puppet::Util::Platform.windows?
+  # Ruby only sets File::ALT_SEPARATOR on Windows and the Ruby standard
+  # library uses that to test what platform it's on. In some places we
+  # would use Puppet.features.microsoft_windows?, but this method can be
+  # used to determine the behavior of the underlying system without
+  # requiring features to be initialized and without side effect.
+  !!File::ALT_SEPARATOR # rubocop:disable Style/DoubleNegation
+end
+
 def platform_uses_ssh(platform)
   # TODO: This seems sub-optimal. We should be able to override/specify what transport to use on a per target basis
   !platform_is_windows?(platform)

--- a/lib/task_helper.rb
+++ b/lib/task_helper.rb
@@ -16,13 +16,25 @@ def run_local_command(command, wd = Dir.pwd)
   stdout
 end
 
+def platform_is_windows?(platform)
+  # TODO: This seems sub-optimal. We should be able to override/specify what the real platform is on a per target basis
+  # (plain_windows)            somewinorg/blah-windows-2019
+  # (plain_windows)            myorg/some_image:windows-server
+  # (bare_win_with_demlimiter) myorg/some_image:win-server-2008
+  # (bare_win_with_demlimiter) myorg/win-2k8r2
+  # No Match                   myorg/winderping    <--- Is this a Windows platform?
+  # (plain_windows)            myorg/windows-server
+  # (plain_windows)            windows-server
+  # (bare_win_with_demlimiter) win-2008
+  # (plain_windows)            webserserver-windows-2008
+  # (bare_win_with_demlimiter) webserver-win-2008
+  windows_regex = %r{(?<plain_windows>windows)|(?<bare_win_with_demlimiter>(?:^|[\/:\-\\;])win(?:[\/:\-\\;]|$))}
+  platform =~ windows_regex
+end
+
 def platform_uses_ssh(platform)
-  uses_ssh = if platform !~ %r{win-}
-               true
-             else
-               false
-             end
-  uses_ssh
+  # TODO: This seems sub-optimal. We should be able to override/specify what transport to use on a per target basis
+  !platform_is_windows?(platform)
 end
 
 def token_from_fogfile

--- a/tasks/vagrant.rb
+++ b/tasks/vagrant.rb
@@ -29,17 +29,6 @@ VF
   end
 end
 
-def on_windows?
-  # TODO: This should probably be in task_helper.rb
-  # Stolen directly from Puppet::Util::Platform.windows?
-  # Ruby only sets File::ALT_SEPARATOR on Windows and the Ruby standard
-  # library uses that to test what platform it's on. In some places we
-  # would use Puppet.features.microsoft_windows?, but this method can be
-  # used to determine the behavior of the underlying system without
-  # requiring features to be initialized and without side effect.
-  !!File::ALT_SEPARATOR # rubocop:disable Style/DoubleNegation
-end
-
 def get_vagrant_dir(platform, vagrant_dirs, i = 0)
   platform_dir = "#{platform}-#{i}"
   if vagrant_dirs.include?(platform_dir)

--- a/tasks/vagrant.rb
+++ b/tasks/vagrant.rb
@@ -30,6 +30,7 @@ VF
 end
 
 def on_windows?
+  # TODO: This should probably be in task_helper.rb
   # Stolen directly from Puppet::Util::Platform.windows?
   # Ruby only sets File::ALT_SEPARATOR on Windows and the Ruby standard
   # library uses that to test what platform it's on. In some places we
@@ -47,29 +48,38 @@ def get_vagrant_dir(platform, vagrant_dirs, i = 0)
   platform_dir
 end
 
-def configure_ssh(platform, ssh_config_path)
-  command = "vagrant ssh-config > #{ssh_config_path}"
-  run_local_command(command, @vagrant_env)
-  ssh_config = Net::SSH::Config.load(ssh_config_path, 'default')
-  case platform
-  when %r{debian.*|ubuntu.*}
-    restart_command = 'service ssh restart'
-  when %r{centos.*}
-    restart_command = 'systemctl restart sshd.service'
+def configure_remoting(platform, remoting_config_path)
+  if platform_uses_ssh(platform)
+    command = "vagrant ssh-config > #{remoting_config_path}"
+    run_local_command(command, @vagrant_env)
+    remoting_config = Net::SSH::Config.load(remoting_config_path, 'default')
+    case platform
+    when %r{debian.*|ubuntu.*}
+      restart_command = 'service ssh restart'
+    when %r{centos.*}
+      restart_command = 'systemctl restart sshd.service'
+    else
+      raise ArgumentError, "Unsupported Platform: '#{platform}'"
+    end
+    # Pre-configure sshd on the platform prior to handing back
+    Net::SSH.start(
+      remoting_config['hostname'],
+      remoting_config['user'],
+      port: remoting_config['port'],
+      keys: remoting_config['identityfile'],
+    ) do |session|
+      session.exec!('sudo su -c "cp -r .ssh /root/."')
+      session.exec!('sudo su -c "sed -i \"s/.*PermitUserEnvironment\s.*/PermitUserEnvironment yes/g\" /etc/ssh/sshd_config"')
+      session.exec!("sudo su -c \"#{restart_command}\"")
+    end
   else
-    raise ArgumentError, "Unsupported Platform: '#{platform}'"
+    command = "vagrant winrm-config > #{remoting_config_path}"
+    run_local_command(command, @vagrant_env)
+    remoting_config = Net::SSH::Config.load(remoting_config_path, 'default')
+    # TODO: Delete remoting_config_path as it's no longer needed
+    # TODO: It's possible we may want to configure WinRM on the target platform beyond the defaults
   end
-  Net::SSH.start(
-    ssh_config['hostname'],
-    ssh_config['user'],
-    port: ssh_config['port'],
-    keys: ssh_config['identityfile'],
-  ) do |session|
-    session.exec!('sudo su -c "cp -r .ssh /root/."')
-    session.exec!('sudo su -c "sed -i \"s/.*PermitUserEnvironment\s.*/PermitUserEnvironment yes/g\" /etc/ssh/sshd_config"')
-    session.exec!("sudo su -c \"#{restart_command}\"")
-  end
-  ssh_config
+  remoting_config
 end
 
 def provision(platform, inventory_location, hyperv_vswitch, hyperv_smb_username, hyperv_smb_password)
@@ -83,19 +93,53 @@ def provision(platform, inventory_location, hyperv_vswitch, hyperv_smb_username,
   provider = on_windows? ? 'hyperv' : 'virtualbox'
   command = "vagrant up --provider #{provider}"
   run_local_command(command, @vagrant_env)
-  ssh_config = configure_ssh(platform, File.join(@vagrant_env, 'ssh-config'))
-  node_name = "#{ssh_config['hostname']}:#{ssh_config['port']}"
   vm_id = File.read(File.join(@vagrant_env, '.vagrant', 'machines', 'default', provider, 'index_uuid'))
+
+  remote_config_file = platform_uses_ssh(platform) ? File.join(@vagrant_env, 'ssh-config') : File.join(@vagrant_env, 'winrm-config')
+  remote_config = configure_remoting(platform, remote_config_file)
+  node_name = "#{remote_config['hostname']}:#{remote_config['port']}"
+
   if platform_uses_ssh(platform)
-    node = { 'name' => node_name,
-             'config' => { 'transport' => 'ssh', 'ssh' => { 'user' => 'root', 'host' => ssh_config['hostname'], 'private-key' => ssh_config['identityfile'][0],
-                                                            'host-key-check' => ssh_config['stricthostkeychecking'], 'port' => ssh_config['port'] } },
-             'facts' => { 'provisioner' => 'vagrant', 'platform' => platform, 'id' => vm_id, 'vagrant_env' => @vagrant_env } }
+    node = {
+      'name' => node_name,
+      'config' => {
+        'transport' => 'ssh',
+        'ssh' => {
+          'user' => 'root',
+          'host' => remote_config['hostname'],
+          'private-key' => remote_config['identityfile'][0],
+          'host-key-check' => remote_config['stricthostkeychecking'],
+          'port' => remote_config['port'],
+        },
+      },
+      'facts' => {
+        'provisioner' => 'vagrant',
+        'platform' => platform,
+        'id' => vm_id,
+        'vagrant_env' => @vagrant_env,
+      },
+    }
     group_name = 'ssh_nodes'
   else
-    node = { 'name' => node_name,
-             'config' => { 'transport' => 'winrm', 'winrm' => { 'user' => 'Administrator', 'password' => '', 'ssl' => false } },
-             'facts' => { 'provisioner' => 'vagrant', 'platform' => platform, 'id' => vm_id, 'vagrant_env' => @vagrant_env } }
+    # TODO: Need to figure out where SSL comes from
+    remote_config['uses_ssl'] ||= false # TODO: Is the default _actually_ false?
+    node = {
+      'name' => node_name,
+      'config' => {
+        'transport'   => 'winrm',
+        'winrm'       => {
+          'user' => remote_config['user'],
+          'password' => remote_config['password'],
+          'ssl' => remote_config['uses_ssl'],
+        },
+      },
+      'facts' => {
+        'provisioner' => 'vagrant',
+        'platform' => platform,
+        'id' => vm_id,
+        'vagrant_env' => @vagrant_env,
+      },
+    }
     group_name = 'winrm_nodes'
   end
   add_node_to_group(inventory_hash, node, group_name)


### PR DESCRIPTION
Prior to this commit the detection for whether or not a target uses is SSH is *actually* a proxy for "is the target a windows node" by checking if the name of the platform includes "win-".

This PR updates the check in two important ways:

1. It moves the check logic to a more correctly named method, `platform_is_windows?` which is clear about what it is checking. This check is still not perfect as it checks on platform name, which is not perfectly reliable.
2. The regex for the name check is improved and documented.

Also prior to this PR, the task used a method, `configure_ssh`, to retrieve the connection information for a target host after vagrant spins the machine up. It did this regardless of whether or not the target has SSH enabled or is a Windows machine. This caused errors when provisioning windows targets.

Further, the WinRM config for the target used defaults which were hardcoded and would cause nodes to never be reachable.

This commit replaces `configure_ssh()` with `configure_remoting()` and retrieves the remoting configuration information regardless of whether the target is using SSH or WinRM. This will also allow us to configure WinRM on the target node if needed in the future.

> **NOTE:**
>
> This check relies on the `platform_uses_ssh()` method which may not be perfectly reliable; for example, a windows machine may have OpenSSH enabled and configured.

This commit further modifies the inventory for WinRM nodes to pass the correct username, password, and node name.

> **NOTE:**
>
> This keeps the pre-configured default which leaves WinRM running over HTTP. It may be worth improving this in the future.