### PR TITLE
(maint) Fix more escaping on Windows

### DIFF
--- a/tasks/docker.rb
+++ b/tasks/docker.rb
@@ -21,8 +21,8 @@ def install_ssh_components(platform, container)
     run_local_command("docker exec #{container} yum clean all")
     run_local_command("docker exec #{container} yum install -y sudo openssh-server openssh-clients")
     ssh_folder = run_local_command("docker exec #{container} ls /etc/ssh/")
-    run_local_command("docker exec #{container} ssh-keygen -t rsa -f /etc/ssh/ssh_host_rsa_key -N ''") unless ssh_folder =~ %r{ssh_host_rsa_key}
-    run_local_command("docker exec #{container} ssh-keygen -t dsa -f /etc/ssh/ssh_host_dsa_key -N ''") unless ssh_folder =~ %r{ssh_host_dsa_key}
+    run_local_command("docker exec #{container} ssh-keygen -t rsa -f /etc/ssh/ssh_host_rsa_key -N \"\"") unless ssh_folder =~ %r{ssh_host_rsa_key}
+    run_local_command("docker exec #{container} ssh-keygen -t dsa -f /etc/ssh/ssh_host_dsa_key -N \"\"") unless ssh_folder =~ %r{ssh_host_dsa_key}
   when %r{opensuse}, %r{sles}
     run_local_command("docker exec #{container} zypper -n in openssh")
     run_local_command("docker exec #{container} ssh-keygen -t rsa -f /etc/ssh/ssh_host_rsa_key")


### PR DESCRIPTION
Previously in commit 36239947 much of the escaping was fixed however the RSA key for CentOS was missed.  Without this change testing CentOS on Windows is impossible.