### PR TITLE
(FM-8260) Disable vagrant synced folders by default

### DIFF
--- a/tasks/vagrant.json
+++ b/tasks/vagrant.json
@@ -26,13 +26,18 @@
       "default": "Default Switch"
     },
     "hyperv_smb_username": {
-      "description": "The username on the Hyper-V machine to use for authenticating the shared folder. Required to use Hyper-V.",
+      "description": "The username on the Hyper-V machine to use for authenticating the shared folder. Required to use Hyper-V with a synced folder.",
       "type": "Optional[String[1]]"
     },
     "hyperv_smb_password": {
-      "description": "The password on the Hyper-V machine to use for authenticating the shared folder. Required to use Hyper-V.",
+      "description": "The password on the Hyper-V machine to use for authenticating the shared folder. Required to use Hyper-V with a synced folder.",
       "type": "Optional[String[1]]",
       "sensitive": true
+    },
+    "enable_synced_folder": {
+      "description": "Whether to use the vagrant synced folder for the provisioned machine",
+      "type": "Optional[Boolean]",
+      "default": false
     }
   },
   "files": [


### PR DESCRIPTION
Prior to this commit the default behavior of vagrant machines
provisioned with the vagrant task used the synced_folder
functionality. This functionality is not used by Litmus but
might be used in other cases.

On Windows, when using the Hyper-V provider for Vagrant, it
is required to also specify a username and password for the
synced_folder. This causes provisioning runs on windows to
often fail by default if the user does not specify credentials.

This commit will cause the default behavior on Windows to
fail less while still enabling workflows that require a
synced folder.