### PR TITLE
Added node object to return data

### DIFF
--- a/tasks/abs.rb
+++ b/tasks/abs.rb
@@ -49,7 +49,7 @@ def provision(platform, inventory_location)
   inventory_hash = get_inventory_hash(inventory_full_path)
   add_node_to_group(inventory_hash, node, group_name)
   File.open(inventory_full_path, 'w') { |f| f.write inventory_hash.to_yaml }
-  { status: 'ok', node_name: hostname }
+  { status: 'ok', node_name: hostname, node: node }
 end
 
 def tear_down(node_name, inventory_location)

--- a/tasks/docker.rb
+++ b/tasks/docker.rb
@@ -98,7 +98,7 @@ def provision(docker_platform, inventory_location)
   group_name = 'ssh_nodes'
   add_node_to_group(inventory_hash, node, group_name)
   File.open(inventory_full_path, 'w') { |f| f.write inventory_hash.to_yaml }
-  { status: 'ok', node_name: "#{hostname}:#{front_facing_port}" }
+  { status: 'ok', node_name: "#{hostname}:#{front_facing_port}", node: node }
 end
 
 def tear_down(node_name, inventory_location)

--- a/tasks/docker_exp.rb
+++ b/tasks/docker_exp.rb
@@ -25,7 +25,7 @@ def provision(docker_platform, inventory_location, append_cli)
   group_name = 'docker_nodes'
   add_node_to_group(inventory_hash, node, group_name)
   File.open(inventory_full_path, 'w') { |f| f.write inventory_hash.to_yaml }
-  { status: 'ok', node_name: container_id }
+  { status: 'ok', node_name: container_id, node: node }
 end
 
 def tear_down(node_name, inventory_location)

--- a/tasks/vagrant.rb
+++ b/tasks/vagrant.rb
@@ -136,7 +136,7 @@ def provision(platform, inventory_location, enable_synced_folder, hyperv_vswitch
   end
   add_node_to_group(inventory_hash, node, group_name)
   File.open(inventory_full_path, 'w') { |f| f.write inventory_hash.to_yaml }
-  { status: 'ok', node_name: node_name }
+  { status: 'ok', node_name: node_name, node: node }
 end
 
 def tear_down(node_name, inventory_location)

--- a/tasks/vmpooler.rb
+++ b/tasks/vmpooler.rb
@@ -50,7 +50,7 @@ def provision(platform, inventory_location, vars)
   inventory_hash = get_inventory_hash(inventory_full_path)
   add_node_to_group(inventory_hash, node, group_name)
   File.open(inventory_full_path, 'w') { |f| f.write inventory_hash.to_yaml }
-  { status: 'ok', node_name: hostname }
+  { status: 'ok', node_name: hostname, node: node }
 end
 
 def tear_down(node_name, inventory_location)


### PR DESCRIPTION
This means that if a plan wants to provision a node and use it right away it can do so with the data that is returned by the task, without having to go back to the inventory and re-read it.