### PR TITLE
Systemd on Centos7

### DIFF
--- a/tasks/docker.rb
+++ b/tasks/docker.rb
@@ -82,10 +82,10 @@ def provision(docker_platform, inventory_location)
     raise 'All front facing ports are in use.' if front_facing_port == 2230
   end
   systemd_volume = if (docker_platform =~ %r{debian|ubuntu|centos}) && (docker_platform !~ %r{debian8|ubuntu14|centos6})
-                                '--volume /sys/fs/cgroup:/sys/fs/cgroup:ro'
-                              else
-                                ''
-                              end
+                     '--volume /sys/fs/cgroup:/sys/fs/cgroup:ro'
+                   else
+                     ''
+                   end
   creation_command = "docker run -d -it #{systemd_volume} --privileged -p #{front_facing_port}:22 --name #{full_container_name} #{docker_platform}"
   run_local_command(creation_command)
   install_ssh_components(platform, full_container_name)

--- a/tasks/docker.rb
+++ b/tasks/docker.rb
@@ -53,7 +53,7 @@ def fix_ssh(platform, container)
   when %r{debian}, %r{ubuntu}
     run_local_command("docker exec #{container} service ssh restart")
   when %r{centos}, %r{^el-}, %r{eos}, %r{fedora}, %r{oracle}, %r{redhat}, %r{scientific}
-    if container !~ %r{7}
+    if container !~ %r{7|systemd}
       run_local_command("docker exec #{container} service sshd restart")
     else
       run_local_command("docker exec -d #{container} /usr/sbin/sshd -D")

--- a/tasks/docker.rb
+++ b/tasks/docker.rb
@@ -81,12 +81,12 @@ def provision(docker_platform, inventory_location)
     break unless stdout.include?(ports)
     raise 'All front facing ports are in use.' if front_facing_port == 2230
   end
-  deb_family_systemd_volume = if (docker_platform =~ %r{debian|ubuntu}) && (docker_platform !~ %r{debian8|ubuntu14})
+  systemd_volume = if (docker_platform =~ %r{debian|ubuntu|centos}) && (docker_platform !~ %r{debian8|ubuntu14|centos6})
                                 '--volume /sys/fs/cgroup:/sys/fs/cgroup:ro'
                               else
                                 ''
                               end
-  creation_command = "docker run -d -it #{deb_family_systemd_volume} --privileged -p #{front_facing_port}:22 --name #{full_container_name} #{docker_platform}"
+  creation_command = "docker run -d -it #{systemd_volume} --privileged -p #{front_facing_port}:22 --name #{full_container_name} #{docker_platform}"
   run_local_command(creation_command)
   install_ssh_components(platform, full_container_name)
   fix_ssh(platform, full_container_name)

--- a/tasks/docker.rb
+++ b/tasks/docker.rb
@@ -53,7 +53,7 @@ def fix_ssh(platform, container)
   when %r{debian}, %r{ubuntu}
     run_local_command("docker exec #{container} service ssh restart")
   when %r{centos}, %r{^el-}, %r{eos}, %r{fedora}, %r{oracle}, %r{redhat}, %r{scientific}
-    if container !~ %r{7|systemd}
+    if (container !~ %r{7}) && (platform !~ %r{systemd})
       run_local_command("docker exec #{container} service sshd restart")
     else
       run_local_command("docker exec -d #{container} /usr/sbin/sshd -D")

--- a/tasks/docker_exp.rb
+++ b/tasks/docker_exp.rb
@@ -12,11 +12,11 @@ def provision(docker_platform, inventory_location, append_cli)
   inventory_full_path = File.join(inventory_location, 'inventory.yaml')
   inventory_hash = get_inventory_hash(inventory_full_path)
 
-  systemd_volume = if (docker_platform =~ %r{debian|ubuntu|centos}) && (docker_platform !~ %r{debian8|ubuntu14|centos6})
-                                '--volume /sys/fs/cgroup:/sys/fs/cgroup:ro'
-                              else
-                                ''
-                              end
+  systemd_volume = if (docker_platform =~ %r{debian|ubuntu}) && (docker_platform !~ %r{debian8|ubuntu14})
+                     '--volume /sys/fs/cgroup:/sys/fs/cgroup:ro'
+                   else
+                     ''
+                   end
   creation_command = "docker run -d -it #{systemd_volume} --privileged #{append_cli} #{docker_platform}"
   container_id = run_local_command(creation_command).strip
   node = { 'name' => container_id,

--- a/tasks/docker_exp.rb
+++ b/tasks/docker_exp.rb
@@ -12,12 +12,12 @@ def provision(docker_platform, inventory_location, append_cli)
   inventory_full_path = File.join(inventory_location, 'inventory.yaml')
   inventory_hash = get_inventory_hash(inventory_full_path)
 
-  deb_family_systemd_volume = if (docker_platform =~ %r{debian|ubuntu}) && (docker_platform !~ %r{debian8|ubuntu14})
+  systemd_volume = if (docker_platform =~ %r{debian|ubuntu|centos}) && (docker_platform !~ %r{debian8|ubuntu14|centos6})
                                 '--volume /sys/fs/cgroup:/sys/fs/cgroup:ro'
                               else
                                 ''
                               end
-  creation_command = "docker run -d -it #{deb_family_systemd_volume} --privileged #{append_cli} #{docker_platform}"
+  creation_command = "docker run -d -it #{systemd_volume} --privileged #{append_cli} #{docker_platform}"
   container_id = run_local_command(creation_command).strip
   node = { 'name' => container_id,
            'config' => { 'transport' => 'docker', 'docker' => { 'shell-command' => @shell_command } },


### PR DESCRIPTION
I'd like to propose these changes to allow for supporting provisioning CentOS systems that have systemd enabled. The debian logic for mounting the systemd volumes is necessary on these systems as well.

I make the assumption that CentOS6 doesn't have systemd by default - I believe this is the case.