### PR TITLE
(FM-8344) Error on exlusive params

### DIFF
--- a/tasks/abs.rb
+++ b/tasks/abs.rb
@@ -87,8 +87,18 @@ platform = params['platform']
 action = params['action']
 node_name = params['node_name']
 inventory_location = params['inventory']
-raise 'specify a node_name if tearing down' if action == 'tear_down' && node_name.nil?
-raise 'specify a platform if provisioning' if action == 'provision' && platform.nil?
+raise 'specify a node_name when tearing down' if action == 'tear_down' && node_name.nil?
+raise 'specify a platform when provisioning' if action == 'provision' && platform.nil?
+unless node_name.nil? ^ platform.nil?
+  case action
+  when 'tear_down'
+    raise 'specify only a node_name, not platform, when tearing down'
+  when 'provision'
+    raise 'specify only a platform, not node_name, when provisioning'
+  else
+    raise 'specify only one of: node_name, platform'
+  end
+end
 
 begin
   result = provision(platform, inventory_location) if action == 'provision'

--- a/tasks/docker.rb
+++ b/tasks/docker.rb
@@ -120,8 +120,18 @@ platform = params['platform']
 action = params['action']
 node_name = params['node_name']
 inventory_location = params['inventory']
-raise 'specify a node_name if tearing down' if action == 'tear_down' && node_name.nil?
-raise 'specify a platform if provisioning' if action == 'provision' && platform.nil?
+raise 'specify a node_name when tearing down' if action == 'tear_down' && node_name.nil?
+raise 'specify a platform when provisioning' if action == 'provision' && platform.nil?
+unless node_name.nil? ^ platform.nil?
+  case action
+  when 'tear_down'
+    raise 'specify only a node_name, not platform, when tearing down'
+  when 'provision'
+    raise 'specify only a platform, not node_name, when provisioning'
+  else
+    raise 'specify only one of: node_name, platform'
+  end
+end
 
 begin
   result = provision(platform, inventory_location) if action == 'provision'

--- a/tasks/docker_exp.rb
+++ b/tasks/docker_exp.rb
@@ -49,8 +49,18 @@ append_cli = params['append_cli']
 inventory_location = params['inventory']
 node_name = params['node_name']
 platform = params['platform']
-raise 'specify a node_name if tearing down' if action == 'tear_down' && node_name.nil?
-raise 'specify a platform if provisioning' if action == 'provision' && platform.nil?
+raise 'specify a node_name when tearing down' if action == 'tear_down' && node_name.nil?
+raise 'specify a platform when provisioning' if action == 'provision' && platform.nil?
+unless node_name.nil? ^ platform.nil?
+  case action
+  when 'tear_down'
+    raise 'specify only a node_name, not platform, when tearing down'
+  when 'provision'
+    raise 'specify only a platform, not node_name, when provisioning'
+  else
+    raise 'specify only one of: node_name, platform'
+  end
+end
 
 begin
   result = provision(platform, inventory_location, append_cli) if action == 'provision'

--- a/tasks/vagrant.rb
+++ b/tasks/vagrant.rb
@@ -168,8 +168,18 @@ end
 hyperv_vswitch = params['hyperv_vswitch'].nil? ? ENV['VAGRANT_HYPERV_VSWITCH'] : params['hyperv_vswitch']
 hyperv_smb_username = params['hyperv_smb_username'].nil? ? ENV['VAGRANT_HYPERV_SMB_USERNAME'] : params['hyperv_smb_username']
 hyperv_smb_password = params['hyperv_smb_password'].nil? ? ENV['VAGRANT_HYPERV_SMB_PASSWORD'] : params['hyperv_smb_password']
-raise 'specify a node_name if tearing down' if action == 'tear_down' && node_name.nil?
-raise 'specify a platform if provisioning' if action == 'provision' && platform.nil?
+raise 'specify a node_name when tearing down' if action == 'tear_down' && node_name.nil?
+raise 'specify a platform when provisioning' if action == 'provision' && platform.nil?
+unless node_name.nil? ^ platform.nil?
+  case action
+  when 'tear_down'
+    raise 'specify only a node_name, not platform, when tearing down'
+  when 'provision'
+    raise 'specify only a platform, not node_name, when provisioning'
+  else
+    raise 'specify only one of: node_name, platform'
+  end
+end
 
 begin
   result = provision(platform, inventory_location, enable_synced_folder, hyperv_vswitch, hyperv_smb_username, hyperv_smb_password) if action == 'provision'

--- a/tasks/vmpooler.rb
+++ b/tasks/vmpooler.rb
@@ -87,8 +87,18 @@ action = params['action']
 node_name = params['node_name']
 inventory_location = params['inventory']
 vars = params['vars']
-raise 'specify a node_name if tearing down' if action == 'tear_down' && node_name.nil?
-raise 'specify a platform if provisioning' if action == 'provision' && platform.nil?
+raise 'specify a node_name when tearing down' if action == 'tear_down' && node_name.nil?
+raise 'specify a platform when provisioning' if action == 'provision' && platform.nil?
+unless node_name.nil? ^ platform.nil?
+  case action
+  when 'tear_down'
+    raise 'specify only a node_name, not platform, when tearing down'
+  when 'provision'
+    raise 'specify only a platform, not node_name, when provisioning'
+  else
+    raise 'specify only one of: node_name, platform'
+  end
+end
 
 begin
   result = provision(platform, inventory_location, vars) if action == 'provision'


### PR DESCRIPTION
Prior to this commit the provisioning tasks allowed a user
to specify both node_name and platform even though those
variables are and should be exclusive parameter sets.

This commit updates the provisioning tasks to raise an
error if both parameters are specified.