### PR TITLE
Clean up SSH setup on docker provisioning

### DIFF
--- a/tasks/docker.rb
+++ b/tasks/docker.rb
@@ -6,7 +6,7 @@ require_relative '../lib/task_helper'
 
 def install_ssh_components(platform, container)
   case platform
-  when %r{debian}, %r{ubuntu}, %{cumulus}
+  when %r{debian}, %r{ubuntu}, %r{cumulus}
     run_local_command("docker exec #{container} apt-get update")
     run_local_command("docker exec #{container} apt-get install -y openssh-server openssh-client")
   when %r{fedora}

--- a/tasks/docker.rb
+++ b/tasks/docker.rb
@@ -6,10 +6,7 @@ require_relative '../lib/task_helper'
 
 def install_ssh_components(platform, container)
   case platform
-  when %r{debian}, %r{ubuntu}
-    run_local_command("docker exec #{container} apt-get update")
-    run_local_command("docker exec #{container} apt-get install -y openssh-server openssh-client")
-  when %r{cumulus}
+  when %r{debian}, %r{ubuntu}, %{cumulus}
     run_local_command("docker exec #{container} apt-get update")
     run_local_command("docker exec #{container} apt-get install -y openssh-server openssh-client")
   when %r{fedora-(2[2-9])}

--- a/tasks/docker.rb
+++ b/tasks/docker.rb
@@ -9,12 +9,11 @@ def install_ssh_components(platform, container)
   when %r{debian}, %r{ubuntu}, %{cumulus}
     run_local_command("docker exec #{container} apt-get update")
     run_local_command("docker exec #{container} apt-get install -y openssh-server openssh-client")
-  when %r{fedora-(2[2-9])}
+  when %r{fedora}
     run_local_command("docker exec #{container} dnf clean all")
     run_local_command("docker exec #{container} dnf install -y sudo openssh-server openssh-clients")
-    run_local_command("docker exec #{container} ssh-keygen -t rsa -f /etc/ssh/ssh_host_rsa_key")
-    run_local_command("docker exec #{container} ssh-keygen -t dsa -f /etc/ssh/ssh_host_dsa_key")
-  when %r{centos}, %r{^el-}, %r{eos}, %r{fedora}, %r{oracle}, %r{redhat}, %r{scientific}
+    run_local_command("docker exec #{container} ssh-keygen -A")
+  when %r{centos}, %r{^el-}, %r{eos}, %r{oracle}, %r{redhat}, %r{scientific}
     run_local_command("docker exec #{container} yum clean all")
     run_local_command("docker exec #{container} yum install -y sudo openssh-server openssh-clients")
     ssh_folder = run_local_command("docker exec #{container} ls /etc/ssh/")


### PR DESCRIPTION
Fedora 30 is out and doesn't match the regex. This might break Fedora 21 or older, but those are EOL. It also uses ssh-keygen -A to automatically generate all host keys.

Debian, Ubuntu and Cumulus are the same and can be one block.