### PR TITLE
(maint) Use a default for inventory location

### DIFF
--- a/tasks/abs.rb
+++ b/tasks/abs.rb
@@ -86,7 +86,7 @@ params = JSON.parse(STDIN.read)
 platform = params['platform']
 action = params['action']
 node_name = params['node_name']
-inventory_location = params['inventory']
+inventory_location = sanitise_inventory_location(params['inventory'])
 raise 'specify a node_name when tearing down' if action == 'tear_down' && node_name.nil?
 raise 'specify a platform when provisioning' if action == 'provision' && platform.nil?
 unless node_name.nil? ^ platform.nil?

--- a/tasks/docker.rb
+++ b/tasks/docker.rb
@@ -115,7 +115,7 @@ params = JSON.parse(STDIN.read)
 platform = params['platform']
 action = params['action']
 node_name = params['node_name']
-inventory_location = params['inventory']
+inventory_location = sanitise_inventory_location(params['inventory'])
 raise 'specify a node_name when tearing down' if action == 'tear_down' && node_name.nil?
 raise 'specify a platform when provisioning' if action == 'provision' && platform.nil?
 unless node_name.nil? ^ platform.nil?

--- a/tasks/docker_exp.rb
+++ b/tasks/docker_exp.rb
@@ -46,7 +46,7 @@ end
 params = JSON.parse(STDIN.read)
 action = params['action']
 append_cli = params['append_cli']
-inventory_location = params['inventory']
+inventory_location = sanitise_inventory_location(params['inventory'])
 node_name = params['node_name']
 platform = params['platform']
 raise 'specify a node_name when tearing down' if action == 'tear_down' && node_name.nil?

--- a/tasks/vagrant.rb
+++ b/tasks/vagrant.rb
@@ -160,7 +160,7 @@ STDERR.puts params
 platform = params['platform']
 action = params['action']
 node_name = params['node_name']
-inventory_location = params['inventory']
+inventory_location = sanitise_inventory_location(params['inventory'])
 enable_synced_folder = params['enable_synced_folder'].nil? ? ENV['VAGRANT_ENABLE_SYNCED_FOLDER'] : params['enable_synced_folder']
 if enable_synced_folder.is_a?(String)
   enable_synced_folder = enable_synced_folder.casecmp('true').zero? ? true : false

--- a/tasks/vmpooler.rb
+++ b/tasks/vmpooler.rb
@@ -85,7 +85,7 @@ params = JSON.parse(STDIN.read)
 platform = params['platform']
 action = params['action']
 node_name = params['node_name']
-inventory_location = params['inventory']
+inventory_location = sanitise_inventory_location(params['inventory'])
 vars = params['vars']
 raise 'specify a node_name when tearing down' if action == 'tear_down' && node_name.nil?
 raise 'specify a platform when provisioning' if action == 'provision' && platform.nil?


### PR DESCRIPTION
Previously the provision tasks stated that the inventory parameter was optional
however if you don't pass this parameter it raises Runtime Errors as you can't
File.join on nil. This commit adds a helper to sanitise the inventory location
and return the current working directory if none is specified.

This commit also cleans up the task_helper to only require libraries it requires
instead of pulling in entire libraries (e.g. litmus) even if they're never used.