### PR TITLE
Add vars support to the docker_exp provisioner

### DIFF
--- a/tasks/docker_exp.json
+++ b/tasks/docker_exp.json
@@ -23,6 +23,10 @@
     "platform": {
       "description": "Platform to provision, eg  ubuntu:14.04",
       "type": "Optional[String[1]]"
+    },
+    "vars": {
+      "description": "YAML string of key/value pairs to add to the inventory vars section",
+      "type": "Optional[String[1]]"
     }
   },
   "files": [


### PR DESCRIPTION
This commit updates the `docker_exp` provisioner with the ability to add
variables set in `provision.yaml` to node entries generated for inventory.yaml.

Logic has been copied from the existing implementation in the `vmpooler` provisioner.