### PR TITLE
Fix quoting on centos docker provisioning. Solves "unexpected EOF while looking for matching `''" error on Windows 10

### DIFF
--- a/tasks/docker.rb
+++ b/tasks/docker.rb
@@ -20,10 +20,10 @@ def install_ssh_components(platform, container)
     # issues with "rpmdb: unable to join the environment" errors
     # This "fix" is from https://www.srv24x7.com/criticalyum-main-error-rpmdb-open-failed/
     run_local_command("docker exec #{container} bash -exc \"rm -f /var/lib/rpm/__db*; "\
-      "db_verify /var/lib/rpm/Packages; "\
-      "rpm --rebuilddb; "\
-      "yum clean all; "\
-      "yum install -y sudo openssh-server openssh-clients\"")
+      'db_verify /var/lib/rpm/Packages; '\
+      'rpm --rebuilddb; '\
+      'yum clean all; '\
+      'yum install -y sudo openssh-server openssh-clients"')
     ssh_folder = run_local_command("docker exec #{container} ls /etc/ssh/")
     run_local_command("docker exec #{container} ssh-keygen -t rsa -f /etc/ssh/ssh_host_rsa_key -N \"\"") unless ssh_folder =~ %r{ssh_host_rsa_key}
     run_local_command("docker exec #{container} ssh-keygen -t dsa -f /etc/ssh/ssh_host_dsa_key -N \"\"") unless ssh_folder =~ %r{ssh_host_dsa_key}

--- a/tasks/docker.rb
+++ b/tasks/docker.rb
@@ -19,11 +19,11 @@ def install_ssh_components(platform, container)
     # sometimes the redhat 6 variant containers like to eat their rpmdb, leading to
     # issues with "rpmdb: unable to join the environment" errors
     # This "fix" is from https://www.srv24x7.com/criticalyum-main-error-rpmdb-open-failed/
-    run_local_command("docker exec #{container} bash -exc 'rm -f /var/lib/rpm/__db*; "\
-      'db_verify /var/lib/rpm/Packages; '\
-      'rpm --rebuilddb; '\
-      'yum clean all; '\
-      "yum install -y sudo openssh-server openssh-clients'")
+    run_local_command("docker exec #{container} bash -exc \"rm -f /var/lib/rpm/__db*; "\
+      "db_verify /var/lib/rpm/Packages; "\
+      "rpm --rebuilddb; "\
+      "yum clean all; "\
+      "yum install -y sudo openssh-server openssh-clients\"")
     ssh_folder = run_local_command("docker exec #{container} ls /etc/ssh/")
     run_local_command("docker exec #{container} ssh-keygen -t rsa -f /etc/ssh/ssh_host_rsa_key -N \"\"") unless ssh_folder =~ %r{ssh_host_rsa_key}
     run_local_command("docker exec #{container} ssh-keygen -t dsa -f /etc/ssh/ssh_host_dsa_key -N \"\"") unless ssh_folder =~ %r{ssh_host_dsa_key}


### PR DESCRIPTION
When running command `bundle exec rake 'litmus:provision[docker, centos:7]'`, as instructed in the tutorial on https://github.com/puppetlabs/puppet_litmus/wiki/Tutorial:-use-Litmus-to-execute-acceptance-tests-with-a-sample-module-(MoTD)#provision-a-target-to-test-against, I get this error on Windows 10:

```
{"target"=>"localhost", "action"=>"task", "object"=>"provision::docker", "status"=>"failure", "result"=>{"_error"=>{"kind"=>"facter_task/failure", "msg"=>"Attempted to run\ncommand:'docker exec centos_7-2222 bash -exc 'rm -f /var/lib/rpm/__db*; db_verify /var/lib/rpm/Packages; rpm --rebuilddb; yum clean all; yum install -y sudo openssh-server openssh-clients''\nstdout:\nstderr:-f: -c: line 0: unexpected EOF while looking for matching `''\n"}}, "node"=>"localhost"}
```

This pull request solves this problem by using " instead of ' and escaping these in the same way as other commands in the same file. I've also tested it on Ubuntu 18.04.3 LTS.

### Versions
OS: Windows 10 Pro 1909
```
John@John$ ruby --version
ruby 2.5.1p57 (2018-03-29 revision 63029) [x64-mingw32]
John@John$ docker --version
Docker version 19.03.5, build 633a0ea
John@John$ puppet --version
6.11.1
John@John$ bolt --version
1.40.0
John@John$ pdk --version
1.14.1
```