### PR TITLE
(MAINT) Downcase platform for windows regex check

### DIFF
--- a/lib/task_helper.rb
+++ b/lib/task_helper.rb
@@ -32,7 +32,7 @@ def platform_is_windows?(platform)
   # (bare_win_with_demlimiter) win-2008
   # (plain_windows)            webserserver-windows-2008
   # (bare_win_with_demlimiter) webserver-win-2008
-  windows_regex = %r{(?<plain_windows>windows)|(?<bare_win_with_demlimiter>(?:^|[\/:\-\\;])win(?:[\/:\-\\;]|$))}
+  windows_regex = %r{(?<plain_windows>windows)|(?<bare_win_with_demlimiter>(?:^|[\/:\-\\;])win(?:[\/:\-\\;]|$))}i
   platform =~ windows_regex
 end
 

--- a/spec/unit/task_helper_spec.rb
+++ b/spec/unit/task_helper_spec.rb
@@ -1,0 +1,21 @@
+require 'task_helper'
+
+describe 'Utility Functions' do
+  context '.platform_is_windows?' do
+    it 'correctly identifies Windows platforms' do
+      expect(platform_is_windows?('somewinorg/blah-windows-2019')).to be_truthy
+      expect(platform_is_windows?('somewinorg/blah-WinDows-2019')).to be_truthy
+      expect(platform_is_windows?('myorg/some_image:windows-server')).to be_truthy
+      expect(platform_is_windows?('myorg/some_image:win-server-2008')).to be_truthy
+      expect(platform_is_windows?('myorg/win-2k8r2')).to be_truthy
+      expect(platform_is_windows?('myorg/windows-server')).to be_truthy
+      expect(platform_is_windows?('windows-server')).to be_truthy
+      expect(platform_is_windows?('win-2008')).to be_truthy
+      expect(platform_is_windows?('webserserver-windows-2008')).to be_truthy
+      expect(platform_is_windows?('webserver-win-2008')).to be_truthy
+      expect(platform_is_windows?('myorg/winderping')).to be_falsey
+      expect(platform_is_windows?('2012r2')).to be_falsey
+      expect(platform_is_windows?('redhat8')).to be_falsey
+    end
+  end
+end


### PR DESCRIPTION
Prior to this commit any specified platform whose name included
Windows rather than windows would fail to be identified as
a Windows machine properly and thereby fail unpredictably.

This commit downcases the platform prior to the comparison.