### PR TITLE
Strip slashes from directories

### DIFF
--- a/tasks/vagrant.rb
+++ b/tasks/vagrant.rb
@@ -63,7 +63,7 @@ VF
 end
 
 def get_vagrant_dir(platform, vagrant_dirs, i = 0)
-  platform_dir = "#{platform}-#{i}"
+  platform_dir = "#{platform}-#{i}".gsub(/[\/\\]/,'-') # Strip slashes
   if vagrant_dirs.include?(platform_dir)
     platform_dir = get_vagrant_dir(platform, vagrant_dirs, i + 1)
   end

--- a/tasks/vagrant.rb
+++ b/tasks/vagrant.rb
@@ -63,7 +63,7 @@ VF
 end
 
 def get_vagrant_dir(platform, vagrant_dirs, i = 0)
-  platform_dir = "#{platform}-#{i}".gsub(/[\/\\]/,'-') # Strip slashes
+  platform_dir = "#{platform}-#{i}".gsub(%r{[\/\\]}, '-') # Strip slashes
   if vagrant_dirs.include?(platform_dir)
     platform_dir = get_vagrant_dir(platform, vagrant_dirs, i + 1)
   end


### PR DESCRIPTION
This means that conflict detection works as anticipated when boxes have a slash in their name