### PR TITLE
Feature/ssh with vagrant

### DIFF
--- a/tasks/vagrant.rb
+++ b/tasks/vagrant.rb
@@ -138,7 +138,7 @@ def provision(platform, inventory_location, enable_synced_folder, provider, cpus
           'private-key' => remote_config['identityfile'][0],
           'host-key-check' => remote_config['stricthostkeychecking'],
           'port' => remote_config['port'],
-          'run-as' => 'root'
+          'run-as' => 'root',
         },
       },
       'facts' => {

--- a/tasks/vagrant.rb
+++ b/tasks/vagrant.rb
@@ -138,7 +138,7 @@ def provision(platform, inventory_location, enable_synced_folder, provider, cpus
           'private-key' => remote_config['identityfile'][0],
           'host-key-check' => remote_config['stricthostkeychecking'],
           'port' => remote_config['port'],
-          'run-as': 'root'
+          'run-as' => 'root'
         },
       },
       'facts' => {

--- a/tasks/vagrant.rb
+++ b/tasks/vagrant.rb
@@ -133,11 +133,12 @@ def provision(platform, inventory_location, enable_synced_folder, provider, cpus
       'config' => {
         'transport' => 'ssh',
         'ssh' => {
-          'user' => 'root',
+          'user' => remote_config['user'],
           'host' => remote_config['hostname'],
           'private-key' => remote_config['identityfile'][0],
           'host-key-check' => remote_config['stricthostkeychecking'],
           'port' => remote_config['port'],
+          'run-as': 'root'
         },
       },
       'facts' => {


### PR DESCRIPTION
Use the user provided by vagrant to ssh to the box. Switch to using root. This will allow `rake litmus:install_agent` to run on boxes where root is not allowed to ssh.