### PR TITLE
Provides support for Terraform

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,14 @@
+# editorconfig.org
+root = true
+
+[*.rb]
+max_line_length = 200
+
+[*]
+charset = utf-8
+end_of_line = lf
+indent_size = 2
+tab_width = 2
+indent_style = space
+insert_final_newline = true
+trim_trailing_whitespace = true

--- a/.gitignore
+++ b/.gitignore
@@ -30,3 +30,6 @@
 *.code-workspace
 Puppetfile
 Vagrantfile
+**/*/.terraform
+*.tfstate
+.terraform

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -4,7 +4,7 @@ require:
 - rubocop-i18n
 AllCops:
   DisplayCopNames: true
-  TargetRubyVersion: '2.1'
+  TargetRubyVersion: '2.4'
   Include:
   - "./**/*.rb"
   Exclude:

--- a/.travis.yml
+++ b/.travis.yml
@@ -43,6 +43,7 @@ branches:
   only:
     - master
     - /^v\d/
+    - /^feature\/.*/
 notifications:
   email: false
   slack:

--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -1,6 +1,7 @@
 {
   "recommendations": [
     "jpogran.puppet-vscode",
-    "rebornix.Ruby"
+    "rebornix.Ruby",
+    "editorconfig.editorconfig"
   ]
 }

--- a/Rakefile
+++ b/Rakefile
@@ -5,6 +5,9 @@ require 'puppet_blacksmith/rake_tasks' if Bundler.rubygems.find_name('puppet-bla
 require 'github_changelog_generator/task' if Bundler.rubygems.find_name('github_changelog_generator').any?
 require 'puppet-strings/tasks' if Bundler.rubygems.find_name('puppet-strings').any?
 
+# development tasks
+Dir.glob('lib/tasks/*.rake').each { |r| load r }
+
 def changelog_user
   return unless Rake.application.top_level_tasks.include? "changelog"
   returnVal = nil || JSON.load(File.read('metadata.json'))['author']

--- a/docs/terraform.md
+++ b/docs/terraform.md
@@ -1,0 +1,305 @@
+# Litmus Terraform Provisioner
+
+#### Table of Contents
+
+- [Litmus Terraform Provisioner](#litmus-terraform-provisioner)
+      - [Table of Contents](#table-of-contents)
+  - [Support](#support)
+  - [Setup](#setup)
+    - [GCP](#gcp)
+  - [Default Templates](#default-templates)
+    - [GCP](#gcp-1)
+  - [Bolt Tasks](#bolt-tasks)
+    - [GCP](#gcp-2)
+    - [Usage](#usage)
+      - [Provision a node](#provision-a-node)
+      - [Tear down a node](#tear-down-a-node)
+  - [Integration with Litmus](#integration-with-litmus)
+    - [GCP](#gcp-3)
+
+## Support
+
+The tasks support the following cloud providers:
+
+  * Google Cloud Platform (GCP)
+
+## Setup
+
+### GCP
+
+In order to provision any infrastructure with the Google Cloud Platform it is necesary for you to provide the following setup by using the [Cloud Console](https://console.cloud.google.com/).
+
+By default the Terraform backend will use the `litmus-compute` identifier for projects and credentials, but you can overwrite this to match your organization's needs.
+
+**Create a Project**
+
+* Create a project named: `litmus-compute`
+
+**Create a Service Account to manage the Project**
+
+* Create a service account under IAM & Admin / Service Account.
+    * Service Account Name: `litmus-compute`
+    * Servcie Account ID: `limtus-compute`
+    * Service Account Description: `Litmus Compute Account`
+* Assign the `Role Owner` role to the `litmus-compute` account.
+* Create a Key in JSON format and save it under `~/.ssh/litmus-compute.json`
+
+**Create and Register an ssh key**
+
+Follow the instructions provided by https://cloud.google.com/compute/docs/instances/adding-removing-ssh-keys. Save your ssh key under `~/.ssh/litmus_compute` and `~/.ssh/litmus_compute.pub`
+
+```bash
+ssh-keygen -t rsa -f ~/.ssh/limtus_compute -C litmus
+chmod 400 ~/.ssh/litmus_compute
+```
+
+Copy and upload your `~/.ssh/litmus_compute.pub` public key using the [Console Metadata Page](https://console.cloud.google.com/compute/metadata/sshKeys).
+
+```bash
+# copy the contents of your key file into your Clipboard
+cat ~/.ssh/litmus_compute.pub| pbcopy
+```
+
+## Default Templates
+
+The tasks provide default templates for `main.tf` and `vars.tf` . These templates are used to provision your infrastructure.
+
+### GCP
+
+**main.tf**
+
+```
+cat .terraform/centos-cloud_centos-7-0/main.tf
+# Based on the official docs provided by
+# https://cloud.google.com/community/tutorials/getting-started-on-gcp-with-terraform
+
+provider "google" {
+  credentials = file(var.credentials_file)
+  project     = var.project
+  region      = var.region
+}
+
+resource "google_compute_instance" "node" {
+  name         = var.vm_name
+  machine_type = var.machine_type
+  zone         = var.zone
+
+  tags = ["litmus"]
+
+  boot_disk {
+    initialize_params {
+      image = var.image
+    }
+  }
+
+  network_interface {
+    network = "default"
+    access_config {
+    }
+  }
+
+  metadata = {
+    ssh-keys = "${var.ssh_user}:${file(var.ssh_public_key)}"
+  }
+
+  labels = {
+    type       = "litmus"
+    created_by = var.created_by
+    owner      = var.owner
+    build_url  = var.build_url
+  }
+}
+
+# return a map of
+# node name => public ip address
+output "node" {
+  value = "${
+    map(
+      google_compute_instance.node.name, google_compute_instance.node.network_interface.0.access_config.0.nat_ip
+    )
+  }"
+}
+```
+
+**vars.tr**
+```
+# Based on the official docs provided by
+# https://cloud.google.com/community/tutorials/getting-started-on-gcp-with-terraform
+
+variable "credentials_file" {
+  type        = string
+  description = "Path to gcp credentials file"
+  default     = "~/.ssh/litmus-compute.json"
+}
+
+variable "ssh_user" {
+  type        = string
+  description = "User used to connect via ssh"
+  default     = "myuser"
+}
+
+variable "ssh_public_key" {
+  type        = string
+  description = "Path to ssh public key"
+  default     = "~/.ssh/litmus_compute.pub"
+}
+
+variable "project" {
+  type        = string
+  description = "Project ID"
+  default     = "litmus-compute"
+}
+
+variable "zone" {
+  type        = string
+  description = "Compute Zone where to create the node"
+  default     = "us-central1-a"
+}
+
+variable "region" {
+  type        = string
+  description = "Compute Region where to create the node"
+  default     = "us-central1"
+}
+
+variable "image" {
+  type        = string
+  description = "The image from which to initialize this disk"
+  default     = "centos-cloud/centos-7"
+}
+
+variable "machine_type" {
+  type        = string
+  description = "Type of machine"
+  default     = "n1-standard-1"
+}
+
+variable "vm_name" {
+  type        = string
+  description = "The vm identifier"
+  default     = "litmus-test-myuser-5459613"
+}
+
+variable "created_by" {
+  type        = string
+  description = "name of the user that created the vm"
+  default     = "myuser"
+}
+
+variable "owner" {
+  type        = string
+  description = "Name of the Department/Team that owns this node (optional)"
+  default     = "myuser"
+}
+
+variable "build_url" {
+  type        = string
+  description = "URL of the CI job that created the vm (optional)"
+  default     = ""
+}
+```
+
+
+## Bolt Tasks
+
+### GCP
+
+### Usage
+
+```bash
+bolt task show provision::terraform_gcp
+
+provision::terraform_gcp - Provision/Tear down a machine on Google Cloud Platform
+
+USAGE:
+bolt task run --targets <node-name> provision::terraform_gcp action=<value> platform=<value> inventory=<value> node_name=<value> credentials_file=<value> project_id=<value> region=<value> zone=<value> machine_type=<value> ssh_user=<value> ssh_private_key=<value> ssh_public_key=<value> ssh_host_key_check=<value> ssh_port=<value> owner=<value> created_by=<value> build_url=<value>
+....
+```
+
+#### Provision a node
+
+```bash
+bolt task run --targets localhost provision::terraform_gcp \
+  action=provision platform=centos-cloud/centos-7
+
+Started on localhost...
+Finished on localhost:
+  {
+    "status": "ok",
+    "node_name": "litmus-test-username-c5ac93c1130bcdab",
+    "node": "35.223.191.200"
+  }
+Successful on 1 target: localhost
+Ran on 1 target in 27.3 sec
+```
+
+You can provide custom main.tf and vars.tf templates
+
+```bash
+bolt task run --targets localhost provision::terraform_gcp \
+  action=provision \
+  platform=centos-cloud/centos-7 \
+  vm_name=foobar \
+  main_template=main.tf.erb \
+  vars_template=vars.tf.erb
+
+```
+
+#### Tear down a node
+
+```bash
+bolt task run --targets localhost provision::terraform_gcp \
+  action=tear_down \
+  node_name=35.223.191.200
+
+```
+
+## Integration with Litmus
+
+### GCP
+
+Provision one node in GCP using the latest Centos 7 Image.
+
+```bash
+bundle exec rake 'litmus:provision[terraform_gcp, centos-cloud/centos-7]'
+```
+
+Provision one node in GCP using a `provision.yml` file.
+
+```bash
+bundle exec rake 'litmus:provision_list[gcp]'
+```
+
+```yaml
+gcp:
+  provisioner: terraform_gcp
+  images: ['centos-cloud/centos-7', 'centos-cloud/centos-6']
+  params:
+    inventory: '.'
+    credentials_file: '~/.ssh/litmus-compute.json'
+    project_id: 'litmus-compute'
+    node_name: 'litmus-test'
+    created_by: My Name
+    region: 'us-central1'
+    zone: 'us-central1-a'
+    machine_type: 'n1-standard-1'
+    ssh_user: my-ssh-user
+    ssh_public_key: '~/.ssh/id_rsa.pub'
+    ssh_host_key_check: false
+    owner: Team Awesome
+    build_url: http://my-jenkins/build/25
+    ssh_port: 22
+```
+
+You can customize the templates used to initialize the Terraform project by passing the `main_template` and `vars_template` parameters.
+
+```yaml
+gcp:
+  provisioner: terraform_gcp
+  images: ['centos-cloud/centos-7']
+  params:
+    ...
+    main_template: 'spec/acceptance/nodeset/centos-7.tf.erb'
+    vars_template: 'spec/acceptance/nodeset/vars.tf.erb'
+```
+

--- a/lib/task_helper.rb
+++ b/lib/task_helper.rb
@@ -1,71 +1,98 @@
-def sanitise_inventory_location(location)
-  # Inventory location is an optional task parameter. If not specified use the current directory
-  location.nil? ? Dir.pwd : location
+# frozen_string_literal: true
+
+require 'puppet_litmus'
+
+# Provision
+module Provision
 end
 
-def get_inventory_hash(inventory_full_path)
-  if File.file?(inventory_full_path)
-    require 'puppet_litmus/inventory_manipulation'
-    PuppetLitmus::InventoryManipulation.inventory_hash_from_inventory_file(inventory_full_path)
-  else
-    { 'version' => 2, 'groups' => [{ 'name' => 'docker_nodes', 'targets' => [] }, { 'name' => 'ssh_nodes', 'targets' => [] }, { 'name' => 'winrm_nodes', 'targets' => [] }] }
+# Provision::TaskHelper
+module Provision::TaskHelper
+  def sanitise_inventory_location(location)
+    # Inventory location is an optional task parameter. If not specified use the current directory
+    location.nil? ? Dir.pwd : location
   end
-end
 
-def run_local_command(command, wd = Dir.pwd)
-  require 'open3'
-  stdout, stderr, status = Open3.capture3(command, chdir: wd)
-  error_message = "Attempted to run\ncommand:'#{command}'\nstdout:#{stdout}\nstderr:#{stderr}"
-  raise error_message unless status.to_i.zero?
-  stdout
-end
-
-def platform_is_windows?(platform)
-  # TODO: This seems sub-optimal. We should be able to override/specify what the real platform is on a per target basis
-  # (plain_windows)            somewinorg/blah-windows-2019
-  # (plain_windows)            myorg/some_image:windows-server
-  # (bare_win_with_demlimiter) myorg/some_image:win-server-2008
-  # (bare_win_with_demlimiter) myorg/win-2k8r2
-  # No Match                   myorg/winderping    <--- Is this a Windows platform?
-  # (plain_windows)            myorg/windows-server
-  # (plain_windows)            windows-server
-  # (bare_win_with_demlimiter) win-2008
-  # (plain_windows)            webserserver-windows-2008
-  # (bare_win_with_demlimiter) webserver-win-2008
-  windows_regex = %r{(?<plain_windows>windows)|(?<bare_win_with_demlimiter>(?:^|[\/:\-\\;])win(?:[\/:\-\\;]|$))}i
-  platform =~ windows_regex
-end
-
-def on_windows?
-  # Stolen directly from Puppet::Util::Platform.windows?
-  # Ruby only sets File::ALT_SEPARATOR on Windows and the Ruby standard
-  # library uses that to test what platform it's on. In some places we
-  # would use Puppet.features.microsoft_windows?, but this method can be
-  # used to determine the behavior of the underlying system without
-  # requiring features to be initialized and without side effect.
-  !!File::ALT_SEPARATOR # rubocop:disable Style/DoubleNegation
-end
-
-def platform_uses_ssh(platform)
-  # TODO: This seems sub-optimal. We should be able to override/specify what transport to use on a per target basis
-  !platform_is_windows?(platform)
-end
-
-def token_from_fogfile
-  fog_file = File.join(Dir.home, '.fog')
-  unless File.file?(fog_file)
-    puts "Cannot file fog file at #{fog_file}"
-    return nil
+  def get_inventory_hash(inventory_full_path)
+    if File.file?(inventory_full_path)
+      require 'puppet_litmus/inventory_manipulation'
+      PuppetLitmus::InventoryManipulation.inventory_hash_from_inventory_file(inventory_full_path)
+    else
+      { 'version' => 2, 'groups' => [{ 'name' => 'docker_nodes', 'targets' => [] }, { 'name' => 'ssh_nodes', 'targets' => [] }, { 'name' => 'winrm_nodes', 'targets' => [] }] }
+    end
   end
-  require 'yaml'
-  contents = YAML.load_file(fog_file)
-  token = contents.dig(:default, :vmpooler_token)
-  token
-rescue
-  puts 'Failed to get vmpooler token from .fog file'
-end
 
-# Workaround for fixing the bash message in stderr when tty is missing
-def fix_missing_tty_error_message(container_id)
-  system("docker exec #{container_id} sed -i 's/^mesg n/tty -s \\&\\& mesg n/g' /root/.profile")
+  def run_local_command(command, wd = Dir.pwd)
+    require 'open3'
+    stdout, stderr, status = Open3.capture3(command, chdir: wd)
+    error_message = "Attempted to run\ncommand:'#{command}'\nstdout:#{stdout}\nstderr:#{stderr}"
+    raise error_message unless status.to_i.zero?
+    stdout
+  end
+
+  def execute(command, opts = {})
+    if opts[:dir]
+      begin
+        Open3.capture3(command, chdir: opts[:dir])
+      rescue Errno::ENOENT => e
+        raise e.message
+      end
+    else
+      begin
+        Open3.capture3(command)
+      rescue Errno::ENOENT => e
+        raise e.message
+      end
+    end
+  end
+
+  def platform_is_windows?(platform)
+    # TODO: This seems sub-optimal. We should be able to override/specify what the real platform is on a per target basis
+    # (plain_windows)            somewinorg/blah-windows-2019
+    # (plain_windows)            myorg/some_image:windows-server
+    # (bare_win_with_demlimiter) myorg/some_image:win-server-2008
+    # (bare_win_with_demlimiter) myorg/win-2k8r2
+    # No Match                   myorg/winderping    <--- Is this a Windows platform?
+    # (plain_windows)            myorg/windows-server
+    # (plain_windows)            windows-server
+    # (bare_win_with_demlimiter) win-2008
+    # (plain_windows)            webserserver-windows-2008
+    # (bare_win_with_demlimiter) webserver-win-2008
+    windows_regex = %r{(?<plain_windows>windows)|(?<bare_win_with_demlimiter>(?:^|[\/:\-\\;])win(?:[\/:\-\\;]|$))}i
+    platform =~ windows_regex
+  end
+
+  def on_windows?
+    # Stolen directly from Puppet::Util::Platform.windows?
+    # Ruby only sets File::ALT_SEPARATOR on Windows and the Ruby standard
+    # library uses that to test what platform it's on. In some places we
+    # would use Puppet.features.microsoft_windows?, but this method can be
+    # used to determine the behavior of the underlying system without
+    # requiring features to be initialized and without side effect.
+    !!File::ALT_SEPARATOR # rubocop:disable Style/DoubleNegation
+  end
+
+  def platform_uses_ssh(platform)
+    # TODO: This seems sub-optimal. We should be able to override/specify what transport to use on a per target basis
+    !platform_is_windows?(platform)
+  end
+
+  def token_from_fogfile
+    fog_file = File.join(Dir.home, '.fog')
+    unless File.file?(fog_file)
+      puts "Cannot file fog file at #{fog_file}"
+      return nil
+    end
+    require 'yaml'
+    contents = YAML.load_file(fog_file)
+    token = contents.dig(:default, :vmpooler_token)
+    token
+  rescue
+    puts 'Failed to get vmpooler token from .fog file'
+  end
+
+  # Workaround for fixing the bash message in stderr when tty is missing
+  def fix_missing_tty_error_message(container_id)
+    system("docker exec #{container_id} sed -i 's/^mesg n/tty -s \\&\\& mesg n/g' /root/.profile")
+  end
 end

--- a/lib/tasks/setup.rake
+++ b/lib/tasks/setup.rake
@@ -1,0 +1,50 @@
+# frozen_string_literal: true
+
+require 'fileutils'
+
+namespace :provision do
+  # a collection of tasks used to help with the development of this module
+  namespace :development do
+    home = ENV['HOME']
+    bolt_directory = File.join(home, '.puppetlabs', 'bolt')
+    sitemodules_directory = File.join(home, '.puppetlabs', 'bolt', 'site-modules')
+    current_directory = File.basename(Dir.getwd)
+
+    desc 'Setup minimal development requirements'
+    task :setup do
+      puppet_modules = <<-PUPPETFILE
+mod 'puppetlabs-puppet_agent'
+mod 'puppetlabs-facts'
+mod 'puppetlabs-puppet_conf'
+    PUPPETFILE
+
+      puppetfile = File.join(bolt_directory, 'Puppetfile')
+
+      puts "[INFO] Check if #{bolt_directory} exists"
+      FileUtils.mkdir_p(bolt_directory) unless File.exist?(bolt_directory)
+
+      puts "[INFO] Check if #{sitemodules_directory} exists"
+      FileUtils.mkdir_p(sitemodules_directory) unless File.exist?(sitemodules_directory)
+
+      puts "[INFO] Check if minimal #{puppetfile} exists"
+      File.write(puppetfile, puppet_modules) unless File.exist?(puppetfile)
+
+      puts "[INFO] Ensure that modules are installed under #{bolt_directory}/modules"
+      `bolt puppetfile install`
+
+      Rake::Task['development:link'].invoke
+    end
+
+    desc "Link current module to #{sitemodules_directory}/"
+    task :link do
+      puts "[INFO] Link this module into #{bolt_directory}/site-modules"
+      `ln -sf #{ENV['PWD']} #{bolt_directory}/site-modules/`
+    end
+
+    desc "Unlink current module from #{sitemodules_directory}/#{current_directory}"
+    task :unlink do
+      puts "[INFO] Unlink this module from #{bolt_directory}/site-modules/#{current_directory}"
+      `unlink #{bolt_directory}/site-modules/#{current_directory}`
+    end
+  end
+end

--- a/lib/terraform.rb
+++ b/lib/terraform.rb
@@ -1,0 +1,456 @@
+# frozen_string_literal: true
+
+require 'yaml'
+require 'fileutils'
+require 'open3'
+require 'puppet_litmus'
+require 'erb'
+
+require_relative 'task_helper.rb'
+
+# Provision
+module Provision
+end
+
+# Provision::Terraform
+module Provision::Terraform
+end
+
+#-------------------------------
+# Terraform Base Implementation
+#-------------------------------
+
+# Terraform::Provision::Base
+class Provision::Terraform::Base
+  include PuppetLitmus
+  include Provision::TaskHelper
+
+  attr_accessor :inventory_hash
+
+  def initialize(opts = {})
+    load_inventory_configuration(opts)
+    load_ssh_configuration(opts)
+    load_template_configuration(opts)
+    load_metadata_configuration(opts)
+    load_template_configuration(opts)
+    load_provider_configuration(opts)
+  end
+
+  # provisions a node and appends it to the inventory file
+  def provision(opts = {})
+    # define where the terraform files for the node should be located
+    @dir = find_or_create_terraform_environment(opts)
+    init(opts)
+    validate(opts)
+    apply(opts)
+    append_to_inventory(output: output(opts))
+  end
+
+  # tear_down a node and removes it from the inventory file
+  def tear_down(opts = {})
+    node_name = opts['node_name']
+    get_terraform_env(node_name)
+    destroy(opts)
+    remove_from_inventory(node_name)
+  end
+
+  private
+
+  def get_terraform_env(node_name)
+    @dir ||= facts_from_node(@inventory_hash, node_name)['terraform_env']
+  end
+
+  def load_provider_configuration(opts = {})
+    @platform = opts['platform'] || 'default'
+    @vm_name = opts['vm_name'] || "litmus-test-#{@created_by}-#{(rand * 100_000_000).to_i}"
+  end
+
+  def load_inventory_configuration(opts = {})
+    @inventory_location = File.expand_path(opts['inventory'] || '.')
+    @inventory_full_path = File.join(@inventory_location, 'inventory.yaml')
+    @inventory_hash = load_inventory
+    @dir = opts['dir'] if opts['dir']
+  end
+
+  def load_ssh_configuration(opts = {})
+    @ssh_user = opts['ssh_user'] || ENV['USER']
+    @ssh_private_key = opts['ssh_private_key'] || '~/.ssh/litmus_compute'
+    @ssh_public_key = opts['ssh_public_key'] || '~/.ssh/litmus_compute.pub'
+    @ssh_host_key_check = opts['ssh_host_key_check'] || false
+    @ssh_port = opts['ssh_port'] || 22
+  end
+
+  def load_metadata_configuration(opts = {})
+    @created_by = opts['created_by'] || ENV['USER']
+    @owner = opts['owner'] || ENV['USER']
+    @build_url = opts['build_url'] || ''
+  end
+
+  def load_template_configuration(opts = {})
+    @main_template = opts['main_template']
+    @vars_template = opts['vars_template']
+  end
+
+  # init
+  # execute terraform init on dir
+  def init(_opts = {})
+    cli_opts = ['-no-color']
+    dir = File.expand_path(@dir) if @dir
+    cli_opts = cli_opts.join(' ')
+
+    if @dir ? Dir.exist?("#{dir}/.terraform") : Dir.exist?(File.expand_path('.terraform'))
+      return { status: 'ok', stdout: 'Terraform has already been initialized' }
+    end
+
+    stdout_str, stderr_str, status = execute("terraform init #{cli_opts}", dir: dir)
+
+    raise stderr_str unless status_is_success?(status)
+
+    { status: 'ok', stdout: stdout_str }
+  end
+
+  # validate
+  # executes terraform validate on dir
+  def validate(_opts = {})
+    dir = File.expand_path(@dir) if @dir
+    stdout_str, stderr_str, status = execute('terraform validate -no-color', dir: dir)
+    raise stderr_str unless status_is_success?(status)
+    { status: 'ok', stdout: stdout_str }
+  end
+
+  # apply
+  # executes terraform apply on dir
+  def apply(opts = {})
+    dir = File.expand_path(@dir) if @dir
+    cli_opts = transcribe_to_cli(opts, dir)
+    stdout_str, stderr_str, status = execute("terraform apply #{cli_opts}", dir: dir)
+    raise stderr_str unless status_is_success?(status)
+    { status: 'ok', stdout: stdout_str }
+  end
+
+  # output
+  # reads the output from the state file
+  def output(_opts = {})
+    dir = File.expand_path(@dir) if @dir
+    stdout_str, stderr_str, status = execute('terraform output -no-color -json', dir: dir)
+    raise stderr_str unless status_is_success?(status)
+    { status: 'ok', stdout: stdout_str }
+  end
+
+  # destroy
+  # executes terraform destroy on dir
+  def destroy(opts = {})
+    dir = File.expand_path(@dir) if @dir
+    cli_opts = transcribe_to_cli(opts, dir)
+    stdout_str, stderr_str, status = execute("terraform destroy #{cli_opts}", dir: dir)
+    raise stderr_str unless status_is_success?(status)
+    { status: 'ok', stdout: stdout_str }
+  end
+
+  def load_inventory
+    if !File.exist?(@inventory_full_path)
+      get_inventory_hash(@inventory_full_path)
+    else
+      inventory_hash_from_inventory_file(@inventory_full_path)
+    end
+  end
+
+  # append_to_inventory
+  # parse the return value of terraform output
+  # append node to invetory file
+  # {
+  #   "node": {
+  #     "sensitive": false,
+  #     "type": [
+  #       "map",
+  #       "string"
+  #     ],
+  #     "value": {
+  #       "node01": "10.178.195.223",
+  #     }
+  #   }
+  # }
+  def append_to_inventory(opts = {})
+    output = JSON.parse(opts[:output][:stdout])
+    nodes = output['node']['value']
+
+    nodes.each do |_vm_name, ip_address|
+      node = {
+        'uri' => ip_address,
+        'config' => {
+          'transport' => 'ssh',
+          'ssh' => {
+            'user' => @ssh_user,
+            'host' => ip_address,
+            'private-key' => @ssh_private_key,
+            'host-key-check' => @ssh_host_key_check,
+            'port' => @ssh_port,
+            'run-as' => 'root',
+          },
+        },
+        'facts' => {
+          'provisioner' => 'terraform_gcp',
+          'platform' => @platform,
+          'id' => @vm_name,
+          'terraform_env' => @dir,
+        },
+      }
+      group_name = 'ssh_nodes'
+      add_node_to_group(@inventory_hash, node, group_name)
+      write_to_inventory_file(@inventory_hash, @inventory_full_path)
+    end
+
+    { status: 'ok', node_name: nodes.first[0], node: nodes.first[1] }
+  end
+
+  # removes a node from inventory file
+  def remove_from_inventory(node_uri)
+    @inventory_hash = remove_node(@inventory_hash, node_uri)
+    write_to_inventory_file(@inventory_hash, @inventory_full_path)
+    FileUtils.rm_r(@dir)
+    STDERR.puts "Removed #{node_uri}"
+    { status: 'ok' }
+  end
+
+  # The apply and destroy CLI opts map from the same task opts to cli opts, share that code.
+  def transcribe_to_cli(opts, dir = nil)
+    cli_opts = ['-auto-approve', '-no-color', '-input=false']
+    cli_opts << "-state=#{File.expand_path(opts[:state], dir)}" if opts[:state]
+    cli_opts << "-state-out=#{File.expand_path(opts[:state_out], dir)}" if opts[:state_out]
+
+    if opts[:target]
+      resources = opts[:target].is_a?(Array) ? opts[:target] : Array(opts[:target])
+      resources.each { |resource| cli_opts << "-target=#{resource}" }
+    end
+
+    opts[:var]&.each { |k, v| cli_opts << "-var '#{k}=#{v}'" }
+
+    if opts[:var_file]
+      var_file_paths = opts[:var_file].is_a?(Array) ? opts[:var_file] : Array(opts[:var_file])
+      var_file_paths.each { |path| cli_opts << "-var-file=#{File.expand_path(path, dir)}" }
+    end
+
+    cli_opts.join(' ')
+  end
+
+  # if the user has provided a directory that contains
+  # their own terraform files we will just use that directory
+  def find_or_create_terraform_environment(opts = {})
+    return opts['dir'] if opts['dir']
+
+    terraform_dirs = Dir.glob("#{File.join(@inventory_location, '.terraform')}/*/").map { |d| File.basename(d) }
+    dir = File.expand_path(File.join(@inventory_location, '.terraform', get_terraform_dir(@platform.tr('/', '_'), terraform_dirs)))
+    # return early if the directory has already exists
+    return dir if File.exist?(dir)
+    FileUtils.mkdir_p dir
+    generate_terraform_files(dir)
+    dir
+  end
+
+  # TODO: This method is not idempotent. I am not sure of the reason to make each provision
+  # call generate a new environment. It almost sounds like the expectation is
+  # that the user will never run provision on the same platform twice. Or that
+  # each call to provision should assume that the user wants a new environemnt to be
+  # created for them.
+  # generate unique terraform directory name
+  def get_terraform_dir(platform, terraform_dirs, i = 0)
+    platform_dir = "#{platform}-#{i}"
+    if terraform_dirs.include?(platform_dir)
+      platform_dir = get_terraform_dir(platform, terraform_dirs, i + 1)
+    end
+    platform_dir
+  end
+
+  def generate_terraform_files(dir)
+    render_main_tf(dir)
+    render_vars_tf(dir)
+  end
+
+  def render_main_tf(dir)
+    template = @main_template ? File.read(@main_template) : main_tf_template
+    tf_file = File.join(dir, 'main.tf')
+    render(template, tf_file)
+  end
+
+  def render_vars_tf(dir)
+    template = @vars_template ? File.read(@vars_template) : vars_tf_template
+    tf_file = File.join(dir, 'vars.tf')
+    render(template, tf_file)
+  end
+
+  def render(template, file_path)
+    File.open(file_path, 'w') do |f|
+      f.write(ERB.new(template).result(binding))
+    end
+  end
+
+  # Each cloud provider must implement this method
+  def main_tf_template
+    <<-TERRAFORM
+    # main.tf
+    TERRAFORM
+  end
+
+  # Each cloud provider must implement this method
+  def vars_tf_template
+    <<-TERRAFORM
+    # vars.tf
+    TERRAFORM
+  end
+
+  def status_is_success?(status)
+    status.to_i.zero?
+  end
+end
+
+#-----------------------------
+# Google Cloud Provider - GCP
+#-----------------------------
+
+# Provision::Terraform::GCP
+class Provision::Terraform::GCP < Provision::Terraform::Base
+  def load_provider_configuration(opts = {})
+    @credentials_file = opts['credentials_file'] || '~/.ssh/litmus-compute.json'
+    @project_id = opts['project_id'] || 'litmus-compute'
+    @platform = opts['platform'] || 'centos-cloud/centos-7'
+    @region = opts['region'] || 'us-central1'
+    @zone = opts['zone'] || 'us-central1-a'
+    @machine_type = opts['machine_type'] || 'n1-standard-1'
+    @vm_name = opts['vm_name'] || "litmus-test-#{@created_by}-#{(rand * 100_000_000).to_i}"
+  end
+
+  def main_tf_template
+    template = <<-TERRAFORM
+    # Based on the official docs provided by
+    # https://cloud.google.com/community/tutorials/getting-started-on-gcp-with-terraform
+
+    provider "google" {
+      credentials = file(var.credentials_file)
+      project     = var.project
+      region      = var.region
+    }
+
+    resource "google_compute_instance" "node" {
+      name         = var.vm_name
+      machine_type = var.machine_type
+      zone         = var.zone
+
+      tags = ["litmus"]
+
+      boot_disk {
+        initialize_params {
+          image = var.image
+        }
+      }
+
+      network_interface {
+        network = "default"
+        access_config {
+        }
+      }
+
+      metadata = {
+        ssh-keys = "${var.ssh_user}:${file(var.ssh_public_key)}"
+      }
+
+      labels = {
+        type = "litmus"
+        created_by = var.created_by
+        owner = var.owner
+        build_url = var.build_url
+      }
+    }
+
+    # return a map of
+    # node name => public ip address
+    output "node" {
+      value =  "${
+        map(
+          google_compute_instance.node.name, google_compute_instance.node.network_interface.0.access_config.0.nat_ip
+        )
+      }"
+    }
+    TERRAFORM
+    template
+  end
+
+  def vars_tf_template
+    template = <<-TERRAFORM
+    # Based on the official docs provided by
+    # https://cloud.google.com/community/tutorials/getting-started-on-gcp-with-terraform
+
+    variable "credentials_file" {
+      type        = string
+      description = "Path to gcp credentials file"
+      default     = "#{@credentials_file}"
+    }
+
+    variable "ssh_user" {
+      type = string
+      description = "User used to connect via ssh"
+      default     = "#{@ssh_user}"
+    }
+
+    variable "ssh_public_key" {
+      type        = string
+      description = "Path to ssh public key"
+      default     = "#{@ssh_public_key}"
+    }
+
+    variable "project" {
+      type        = string
+      description = "Project ID"
+      default     = "#{@project_id}"
+    }
+
+    variable "zone" {
+      type = string
+      description = "Compute Zone where to create the node"
+      default     = "#{@zone}"
+    }
+
+    variable "region" {
+      type = string
+      description = "Compute Region where to create the node"
+      default     = "#{@region}"
+    }
+
+    variable "image" {
+      type        = string
+      description = "The image from which to initialize this disk"
+      default     = "#{@platform}"
+    }
+
+    variable "machine_type" {
+      type        = string
+      description = "Type of machine"
+      default     = "#{@machine_type}"
+    }
+
+    variable "vm_name" {
+      type        = string
+      description = "The vm identifier"
+      default     = "#{@vm_name}"
+    }
+
+    variable "created_by" {
+      type        = string
+      description = "name of the user that created the vm"
+      default     = "#{@created_by}"
+    }
+
+    variable "owner" {
+      type = string
+      description = "Name of the Department/Team that owns this node (optional)"
+      default = "#{@owner}"
+    }
+
+    variable "build_url" {
+      type = string
+      description = "URL of the CI job that created the vm (optional)"
+      default = "#{@build_url}"
+    }
+  TERRAFORM
+    template
+  end
+end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'puppetlabs_spec_helper/module_spec_helper'
 require 'rspec-puppet-facts'
 

--- a/spec/unit/provision_terraform_spec.rb
+++ b/spec/unit/provision_terraform_spec.rb
@@ -1,0 +1,343 @@
+# frozen_string_literal: true
+
+require 'fileutils'
+require 'terraform'
+
+describe 'Provision::Terraform::Base' do
+  let(:tmpdir) { Dir.mktmpdir }
+
+  let(:terraform) { Provision::Terraform::Base }
+
+  describe '#initialize' do
+    it 'creates an instance with all defaults' do
+      tf = terraform.new
+      expect(tf).to be_an_instance_of(terraform)
+    end
+
+    it 'accepts a parameters hash' do
+      params = {
+        'dir' => tmpdir,
+        'inventory' => tmpdir,
+      }
+      tf = terraform.new(params)
+      expect(tf).to be_an_instance_of(terraform)
+    end
+  end
+
+  describe '#tear_down' do
+    let(:params) do
+      {
+        'dir' => tmpdir,
+        'inventory' => tmpdir,
+      }
+    end
+    let(:tf) { terraform.new(params) }
+
+    after(:each) do
+      FileUtils.remove_entry(tmpdir) if File.exist?(tmpdir)
+    end
+
+    it 'executes terraform destroy' do
+      cmd = 'terraform destroy -auto-approve -no-color -input=false'
+      opts = { dir: tmpdir }
+      allow(tf).to receive(:execute).with(cmd, opts).and_return(['ok', '', 0])
+      allow(tf).to receive(:remove_from_inventory).with('192.168.1.1').and_return(status: 'ok')
+      result = tf.tear_down('node_name' => '192.168.1.1')
+      expect(result[:status]).to eq('ok')
+    end
+  end
+
+  describe '#init' do
+    let(:params) do
+      {
+        'dir' => tmpdir,
+        'inventory' => tmpdir,
+      }
+    end
+    let(:tf) { terraform.new(params) }
+
+    after(:each) do
+      FileUtils.remove_entry(tmpdir) if File.exist?(tmpdir)
+    end
+
+    it 'initializes an empty directory' do
+      result = tf.send(:init)
+      expect(result[:status]).to eq('ok')
+      expect(result[:stdout]).to match('Terraform initialized in an empty directory!')
+    end
+
+    it 'initializes a directory with tf scripts' do
+      result = tf.send(:init)
+      expect(result[:status]).to eq('ok')
+    end
+  end
+
+  describe '#validate' do
+    let(:params) do
+      {
+        'dir' => tmpdir,
+        'inventory' => tmpdir,
+      }
+    end
+    let(:tf) { terraform.new(params) }
+
+    after(:each) do
+      FileUtils.remove_entry(tmpdir) if File.exist?(tmpdir)
+    end
+
+    it 'executes terraform validate on dir' do
+      cmd = 'terraform validate -no-color'
+      opts = { dir: tmpdir }
+      allow(tf).to receive(:execute).with(cmd, opts).and_return(['Success! The configuration is valid.', '', 0])
+
+      result = tf.send(:validate)
+      expect(result[:status]).to eq('ok')
+      expect(result[:stdout]).to match('Success! The configuration is valid.')
+    end
+
+    it 'raises exception when terraform validate fails' do
+      cmd = 'terraform validate -no-color'
+      opts = { dir: tmpdir }
+      allow(tf).to receive(:execute).with(cmd, opts).and_return(['I was doing something.', 'Bad thing!', 1])
+
+      expect {
+        tf.send(:validate)
+      }.to raise_error('Bad thing!')
+    end
+  end
+
+  describe '#apply' do
+    let(:params) do
+      {
+        'dir' => tmpdir,
+        'inventory' => tmpdir,
+      }
+    end
+    let(:tf) { terraform.new(params) }
+
+    after(:each) do
+      FileUtils.remove_entry(tmpdir) if File.exist?(tmpdir)
+    end
+
+    it 'executes terraform apply on dir' do
+      cmd = 'terraform apply -auto-approve -no-color -input=false'
+      opts = { dir: tmpdir }
+      allow(tf).to receive(:execute).with(cmd, opts).and_return(['Apply complete!', '', 0])
+
+      result = tf.send(:apply)
+      expect(result[:status]).to eq('ok')
+      expect(result[:stdout]).to match('Apply complete!')
+    end
+
+    it 'raises exception when terraform apply fails' do
+      cmd = 'terraform apply -auto-approve -no-color -input=false'
+      opts = { dir: tmpdir }
+      allow(tf).to receive(:execute).with(cmd, opts).and_return(['I was doing something.', 'Bad thing!', 1])
+
+      expect {
+        tf.send(:apply)
+      }.to raise_error('Bad thing!')
+    end
+  end
+
+  describe '#output' do
+    let(:params) do
+      {
+        'dir' => tmpdir,
+        'inventory' => tmpdir,
+      }
+    end
+    let(:tf) { terraform.new(params) }
+
+    after(:each) do
+      FileUtils.remove_entry(tmpdir) if File.exist?(tmpdir)
+    end
+
+    it 'executes terraform output on dir' do
+      output = {
+        "node": {
+          "sensitive": false,
+          "type": [
+            'map',
+            'string',
+          ],
+          "value": {
+            "node_name_01": '10.178.196.188',
+          },
+        },
+      }
+      cmd = 'terraform output -no-color -json'
+      opts = { dir: tmpdir }
+      allow(tf).to receive(:execute).with(cmd, opts).and_return([output.to_json, '', 0])
+
+      result = tf.send(:output)
+      expect(result[:status]).to eq('ok')
+      expect(result[:stdout]).to match('"node"')
+    end
+
+    it 'raises exception when terraform destroy fails' do
+      cmd = 'terraform output -no-color -json'
+      opts = { dir: tmpdir }
+      allow(tf).to receive(:execute).with(cmd, opts).and_return(['I was doing something.', 'Bad thing!', 1])
+
+      expect {
+        tf.send(:output)
+      }.to raise_error('Bad thing!')
+    end
+  end
+
+  describe '#destroy' do
+    let(:params) do
+      {
+        'dir' => tmpdir,
+        'inventory' => tmpdir,
+      }
+    end
+    let(:tf) { terraform.new(params) }
+
+    after(:each) do
+      FileUtils.remove_entry(tmpdir) if File.exist?(tmpdir)
+    end
+
+    it 'executes terraform destroy on dir' do
+      cmd = 'terraform destroy -auto-approve -no-color -input=false'
+      opts = { dir: tmpdir }
+      allow(tf).to receive(:execute).with(cmd, opts).and_return(['Destroy complete!', '', 0])
+
+      result = tf.send(:destroy)
+      expect(result[:status]).to eq('ok')
+      expect(result[:stdout]).to match('Destroy complete!')
+    end
+
+    it 'raises exception when terraform destroy fails' do
+      cmd = 'terraform destroy -auto-approve -no-color -input=false'
+      opts = { dir: tmpdir }
+      allow(tf).to receive(:execute).with(cmd, opts).and_return(['I was doing something.', 'Bad thing!', 1])
+
+      expect {
+        tf.send(:destroy)
+      }.to raise_error('Bad thing!')
+    end
+  end
+
+  describe '#append_to_inventory' do
+    let(:params) do
+      {
+        'dir' => tmpdir,
+        'inventory' => tmpdir,
+        'vm_name' => 'litmus-test',
+      }
+    end
+    let(:tf) { terraform.new(params) }
+
+    after(:each) do
+      FileUtils.remove_entry(tmpdir) if File.exist?(tmpdir)
+    end
+
+    it 'returns information about newly added node' do
+      stdout = '{"node":{"sensitive":false,"type":["map","string"],"value":{"litmus-test":"10.178.196.188"}}}'
+      opts = {
+        output: {
+          stdout: stdout,
+        },
+      }
+      result = tf.send(:append_to_inventory, opts)
+      expect(result[:status]).to eq('ok')
+      expect(result[:node_name]).to eq('litmus-test')
+      expect(result[:node]).to eq('10.178.196.188')
+    end
+
+    it 'appends a node to the ssh_nodes group' do
+      inventory_hash = {
+        'version' => 2,
+        'groups' => [
+          { 'name' => 'docker_nodes', 'targets' => [] },
+          { 'name' => 'ssh_nodes', 'targets' => [] },
+          { 'name' => 'winrm_nodes', 'targets' => [] },
+        ],
+      }
+      group_name = 'ssh_nodes'
+      node = {
+        'uri' => '10.178.196.188',
+        'config' => {
+          'transport' => 'ssh',
+          'ssh' => {
+            'user' => ENV['USER'],
+            'host' => '10.178.196.188',
+            'private-key' => '~/.ssh/litmus_compute',
+            'host-key-check' => false,
+            'port' => 22,
+            'run-as' => 'root',
+          },
+        },
+        'facts' => {
+          'provisioner' => 'terraform_gcp',
+          'platform' => 'default',
+          'id' => 'litmus-test',
+          'terraform_env' => tmpdir,
+        },
+      }
+
+      stdout = '{"node":{"sensitive":false,"type":["map","string"],"value":{"litmus-test":"10.178.196.188"}}}'
+      opts = {
+        output: {
+          stdout: stdout,
+        },
+      }
+      expect(tf).to receive(:add_node_to_group).with(inventory_hash, node, group_name)
+      tf.send(:append_to_inventory, opts)
+    end
+  end
+
+  describe '#remove_from_inventory' do
+    let(:params) do
+      {
+        'dir' => tmpdir,
+        'inventory' => tmpdir,
+        'vm_name' => 'litmus-test',
+      }
+    end
+    let(:tf) { terraform.new(params) }
+
+    after(:each) do
+      FileUtils.remove_entry(tmpdir) if File.exist?(tmpdir)
+    end
+
+    it 'removes node from inventory file' do
+      node_uri = '10.178.196.188'
+      inventory_hash = {
+        'version' => 2,
+        'groups' => [
+          { 'name' => 'docker_nodes', 'targets' => [] },
+          { 'name' => 'ssh_nodes',
+            'targets' => [
+              { 'uri' => '10.178.196.188',
+                'config' => {
+                  'transport' => 'ssh',
+                  'ssh' => {
+                    'user' => 'litmus',
+                    'host' => '10.178.196.188',
+                    'private-key' => '~/.ssh/litmus_compute',
+                    'host-key-check' => false,
+                    'port' => 22,
+                    'run-as' => 'root',
+                  },
+                },
+                'facts' => {
+                  'provisioner' => 'terraform_gcp',
+                  'platform' => 'default',
+                  'id' => 'litmus-test',
+                  'terraform_env' => tmpdir,
+                } },
+            ] },
+          { 'name' => 'winrm_nodes', 'targets' => [] },
+        ],
+      }
+
+      tf.inventory_hash = inventory_hash
+      expect(tf).to receive(:remove_node).with(inventory_hash, node_uri)
+      result = tf.send(:remove_from_inventory, node_uri)
+      expect(result[:status]).to eq('ok')
+    end
+  end
+end

--- a/spec/unit/task_helper_spec.rb
+++ b/spec/unit/task_helper_spec.rb
@@ -1,7 +1,11 @@
+# frozen_string_literal: true
+
 require 'task_helper'
 
 describe 'Utility Functions' do
-  context '.platform_is_windows?' do
+  include Provision::TaskHelper
+
+  context 'platform_is_windows?' do
     it 'correctly identifies Windows platforms' do
       expect(platform_is_windows?('somewinorg/blah-windows-2019')).to be_truthy
       expect(platform_is_windows?('somewinorg/blah-WinDows-2019')).to be_truthy

--- a/tasks/abs.rb
+++ b/tasks/abs.rb
@@ -1,10 +1,14 @@
 #!/usr/bin/env ruby
+# frozen_string_literal: true
+
 require 'json'
 require 'net/http'
 require 'yaml'
 require 'puppet_litmus'
 require 'etc'
 require_relative '../lib/task_helper'
+
+include Provision::TaskHelper
 
 def provision(platform, inventory_location)
   include PuppetLitmus::InventoryManipulation

--- a/tasks/docker.json
+++ b/tasks/docker.json
@@ -1,3 +1,4 @@
+
 {
   "puppet_task_version": 1,
   "supports_noop": false,

--- a/tasks/docker.rb
+++ b/tasks/docker.rb
@@ -1,8 +1,12 @@
 #!/usr/bin/env ruby
+# frozen_string_literal: true
+
 require 'json'
 require 'yaml'
 require 'puppet_litmus'
 require_relative '../lib/task_helper'
+
+include Provision::TaskHelper
 
 def install_ssh_components(platform, version, container)
   case platform
@@ -29,8 +33,8 @@ def install_ssh_components(platform, version, container)
       run_local_command("docker exec #{container} yum install -y sudo openssh-server openssh-clients")
     end
     ssh_folder = run_local_command("docker exec #{container} ls /etc/ssh/")
-    run_local_command("docker exec #{container} ssh-keygen -t rsa -f /etc/ssh/ssh_host_rsa_key -N \"\"") unless ssh_folder =~ %r{ssh_host_rsa_key}
-    run_local_command("docker exec #{container} ssh-keygen -t dsa -f /etc/ssh/ssh_host_dsa_key -N \"\"") unless ssh_folder =~ %r{ssh_host_dsa_key}
+    run_local_command("docker exec #{container} ssh-keygen -t rsa -f /etc/ssh/ssh_host_rsa_key -N \"\"") unless ssh_folder.match?(%r{ssh_host_rsa_key})
+    run_local_command("docker exec #{container} ssh-keygen -t dsa -f /etc/ssh/ssh_host_dsa_key -N \"\"") unless ssh_folder.match?(%r{ssh_host_dsa_key})
   when %r{opensuse}, %r{sles}
     run_local_command("docker exec #{container} zypper -n in openssh")
     run_local_command("docker exec #{container} ssh-keygen -t rsa -f /etc/ssh/ssh_host_rsa_key")

--- a/tasks/docker_exp.rb
+++ b/tasks/docker_exp.rb
@@ -1,8 +1,12 @@
 #!/usr/bin/env ruby
+# frozen_string_literal: true
+
 require 'json'
 require 'yaml'
 require 'puppet_litmus'
 require_relative '../lib/task_helper'
+
+include Provision::TaskHelper
 
 # TODO: detect what shell to use
 @shell_command = 'bash -lc'

--- a/tasks/run_tests.rb
+++ b/tasks/run_tests.rb
@@ -1,6 +1,10 @@
 #!/usr/bin/env ruby
+# frozen_string_literal: true
+
 require 'puppet_litmus'
 require_relative '../lib/task_helper'
+
+include Provision::TaskHelper
 
 def run_tests(sut, test_path)
   test = "bundle exec rspec #{test_path} --format progress"

--- a/tasks/terraform_gcp.json
+++ b/tasks/terraform_gcp.json
@@ -1,0 +1,102 @@
+{
+  "puppet_task_version": 1,
+  "supports_noop": false,
+  "input_method": "stdin",
+  "description": "Provision/Tear down a machine on Google Cloud Platform",
+  "parameters": {
+    "action": {
+      "description": "Action to perform, tear_down or provision",
+      "type": "Enum[provision, tear_down]",
+      "default": "provision"
+    },
+    "inventory": {
+      "description": "Location of the inventory file",
+      "type": "Optional[String[1]]"
+    },
+    "platform": {
+      "description": "Platform to provision. Corresponds to the cloud image id used to provision the vm. eg centos-cloud/centos-7",
+      "type": "Optional[String[1]]"
+    },
+    "node_name": {
+      "description": "The name of the node. Used by tear_down. Is incompatible with platform",
+      "type": "Optional[String[1]]"
+    },
+    "credentials_file": {
+      "type": "Optional[String[1]]",
+      "description": "Path to json credentials file.",
+      "default": "~/.ssh/litmus-compute.json"
+    },
+    "project_id": {
+      "type": "Optional[String[1]]",
+      "description": "Id of the Google Compute Project",
+      "default": "litmus-compute"
+    },
+    "region": {
+      "type": "Optional[String[1]]",
+      "description": "Compute Region where resources will be created",
+      "default": "us-central1"
+    },
+    "zone": {
+      "type": "Optional[String[1]]",
+      "description": "Compute Zone where resources will be created",
+      "default": "us-central1-a"
+    },
+    "machine_type": {
+      "type": "Optional[String[1]]",
+      "description": "Type of machine",
+      "default": "n1-standard-1"
+    },
+    "vm_name": {
+      "type": "Optional[String[1]]",
+      "description": "Overwrite the VM name. Defaults to litmus-test-[CREATED_BY]-[RANDOMNUMBER]"
+    },
+    "ssh_user": {
+      "type": "Optional[String[1]]",
+      "description": "User that litmus will use to ssh into the vm. Defaults to $USER"
+    },
+    "ssh_private_key": {
+      "type": "Optional[String[1]]",
+      "description": "Private ssh key used by \"ssh_user\" to connect to the vm.",
+      "default": "~/.ssh/litmus_compute"
+    },
+    "ssh_public_key": {
+      "type": "Optional[String[1]]",
+      "description": "Public ssh key used by \"ssh_user\" to connect to the vm.",
+      "default": "~/.ssh/litmus_compute.pub"
+    },
+    "ssh_host_key_check": {
+      "type": "Optional[Boolean]",
+      "description": "Host verification enabled.",
+      "default": false
+    },
+    "ssh_port": {
+      "type": "Optional[Integer]",
+      "description": "Port used to connect to the vm via ssh.",
+      "default": 22
+    },
+    "owner": {
+      "type": "Optional[String[1]]",
+      "description": "Metadata. Adds a label to the vm to identify the team/owner that owns the vm. Defaults to $USER."
+    },
+    "created_by": {
+      "type": "Optional[String[1]]",
+      "description": "Metadata. Adds a label to the vm to indentify the user that created the resources. Defaults to $USER."
+    },
+    "build_url": {
+      "type": "Optional[String[1]]",
+      "description": "Metadata. Adds a label to the vm to identify the CI build url that created the vm."
+    },
+    "main_template": {
+      "type": "Optional[String[1]]",
+      "description": "Path to a custom main.tf file template. The file will be parsed as ERB."
+    },
+    "vars_template": {
+      "type": "Optional[String[1]]",
+      "description": "Path to a custom vars.tf file template. The file will be parsed as ERB."
+    }
+  },
+  "files": [
+    "provision/lib/task_helper.rb",
+    "provision/lib/terraform.rb"
+  ]
+}

--- a/tasks/terraform_gcp.rb
+++ b/tasks/terraform_gcp.rb
@@ -1,0 +1,52 @@
+#!/usr/bin/env ruby
+# frozen_string_literal: true
+
+require 'json'
+require_relative '../lib/task_helper.rb'
+require_relative '../lib/terraform.rb'
+
+require 'pp'
+
+include Provision::TaskHelper
+
+params = JSON.parse(STDIN.read)
+STDERR.puts params
+platform = params['platform']
+action = params['action']
+node_name = params['node_name']
+params['inventory'] = sanitise_inventory_location(params['inventory'])
+
+raise 'specify a node_name when tearing down' if action == 'tear_down' && node_name.nil?
+raise 'specify a platform when provisioning' if action == 'provision' && platform.nil?
+unless node_name.nil? ^ platform.nil?
+  case action
+  when 'tear_down'
+    raise 'specify only a node_name, not platform, when tearing down'
+  when 'provision'
+    raise 'specify only a platform, not node_name, when provisioning'
+  else
+    raise 'specify only one of: node_name, platform'
+  end
+end
+
+begin
+  terraform = Provision::Terraform::GCP.new(params)
+  STDERR.puts "[DEBUG] #{terraform}"
+  result = case action
+           when 'provision'
+             terraform.provision(params)
+           when 'tear_down'
+             terraform.tear_down(params)
+           else
+             raise 'action only supports provision or teardown'
+           end
+  puts result.to_json
+  exit 0
+rescue => e
+  STDERR.puts "[ERROR] #{e.backtrace.join("\n")}"
+  puts({ _error: { kind: 'facter_task/failure', msg: e.message } }.to_json)
+  e.backtrace.each do |b|
+    puts({ _error: { kind: 'facter_task/failure', msg: b } }.to_json)
+  end
+  exit 1
+end

--- a/tasks/update_node_pp.rb
+++ b/tasks/update_node_pp.rb
@@ -1,4 +1,6 @@
 #!/opt/puppetlabs/puppet/bin/ruby
+# frozen_string_literal: true
+
 require 'json'
 require 'open3'
 require 'puppet'

--- a/tasks/update_site_pp.rb
+++ b/tasks/update_site_pp.rb
@@ -1,4 +1,6 @@
 #!/opt/puppetlabs/puppet/bin/ruby
+# frozen_string_literal: true
+
 require 'json'
 require 'open3'
 require 'puppet'

--- a/tasks/vagrant.rb
+++ b/tasks/vagrant.rb
@@ -1,4 +1,6 @@
 #!/usr/bin/env ruby
+# frozen_string_literal: true
+
 require 'json'
 require 'net/http'
 require 'yaml'
@@ -6,6 +8,8 @@ require 'puppet_litmus'
 require 'fileutils'
 require 'net/ssh'
 require_relative '../lib/task_helper'
+
+include Provision::TaskHelper
 
 def vagrant_version
   return @vagrant_version if defined?(@vagrant_version)

--- a/tasks/vmpooler.rb
+++ b/tasks/vmpooler.rb
@@ -1,10 +1,12 @@
 #!/usr/bin/env ruby
+# frozen_string_literal: true
+
 require 'json'
 require 'net/http'
 require 'yaml'
 require 'puppet_litmus'
 require_relative '../lib/task_helper'
-
+include Provision::TaskHelper
 def provision(platform, inventory_location, vars)
   include PuppetLitmus::InventoryManipulation
   vmpooler_hostname = if ENV['VMPOOLER_HOSTNAME'].nil?


### PR DESCRIPTION
Adds a new Terraform provisioner.

The initial implementation allows a user to provision infrastructure into GCP using two hardcoded templates. The provision:terraform_gcp task allows the user to pass custom templates to overwrite the default Terraform templates.

It is possible to extend this to other cloud providers by subclassing Provision::Terraform and providing the appropriate templates.

This change also provides a set of rake tasks that can help a developer configure their environment.

```
➜  provision git:(feature/terraform-backend) rake -vT | grep provision:development
rake provision:development:link                                                 # Link current module to /Users/jalvarezsamayoa/.puppetlabs/bolt/site-modules/
rake provision:development:setup                                                # Setup minimal development requirements
rake provision:development:unlink                                               # Unlink current module from /Users/jalvarezsamayoa/.puppetlabs/bolt/site-modules/provision
```

Running `rake provision:development:setup` will create the necesary directories under `$HOME/.pupetlab` to make the source's task available to the console.
