### PR TITLE
docker: support podman; improve handling of OS distribution/version for non-litmusimage images

### DIFF
--- a/tasks/docker.rb
+++ b/tasks/docker.rb
@@ -61,6 +61,13 @@ def fix_ssh(distro, version, container)
   when %r{debian}, %r{ubuntu}
     run_local_command("docker exec #{container} service ssh restart")
   when %r{centos}, %r{^el-}, %r{eos}, %r{fedora}, %r{oracle}, %r{redhat}, %r{scientific}, %r{amazonlinux}
+    # Current RedHat/CentOs 7 packs an old version of pam, which are missing a
+    # crucial patch when running unprivileged containers.  See:
+    # https://bugzilla.redhat.com/show_bug.cgi?id=1728777
+    if distro =~ %r{redhat|centos} && version =~ %r{7}
+      run_local_command("docker exec #{container} sed 's@session\s*required\s*pam_loginuid.so@session optional pam_loginuid.so@g' -i /etc/pam.d/sshd")
+    end
+
     if version !~ %r{7|8|2}
       run_local_command("docker exec #{container} service sshd restart")
     else

--- a/tasks/docker.rb
+++ b/tasks/docker.rb
@@ -114,7 +114,8 @@ def provision(image, inventory_location, vars)
                                 ''
                               end
   creation_command = %W[
-    docker run -d -it #{deb_family_systemd_volume} --privileged
+    docker run -d -it --privileged
+    #{deb_family_systemd_volume} --tmpfs /tmp:exec
     -p #{front_facing_port}:22
     --name #{full_container_name} #{image}
   ].join(' ')

--- a/tasks/docker.rb
+++ b/tasks/docker.rb
@@ -107,7 +107,7 @@ def provision(image, inventory_location, vars)
     break unless stdout.include?(ports)
     raise 'All front facing ports are in use.' if front_facing_port == 2230
   end
-  full_container_name = "#{distro}_#{version}-#{front_facing_port}"
+  full_container_name = "#{image.gsub(%r{[/:]}, '_')}-#{front_facing_port}"
   deb_family_systemd_volume = if (image =~ %r{debian|ubuntu}) && (image !~ %r{debian8|ubuntu14})
                                 '--volume /sys/fs/cgroup:/sys/fs/cgroup:ro'
                               else

--- a/tasks/docker.rb
+++ b/tasks/docker.rb
@@ -120,12 +120,7 @@ def provision(image, inventory_location, vars)
                               else
                                 ''
                               end
-  creation_command = %W[
-    docker run -d -it --privileged
-    #{deb_family_systemd_volume} --tmpfs /tmp:exec
-    -p #{front_facing_port}:22
-    --name #{full_container_name} #{image}
-  ].join(' ')
+  creation_command = "docker run -d -it --privileged #{deb_family_systemd_volume} --tmpfs /tmp:exec -p #{front_facing_port}:22 --name #{full_container_name} #{image}"
   run_local_command(creation_command).strip
   install_ssh_components(distro, version, full_container_name)
   fix_ssh(distro, version, full_container_name)

--- a/tasks/docker.rb
+++ b/tasks/docker.rb
@@ -64,7 +64,7 @@ def fix_ssh(platform, container)
     if container !~ %r{7|8|2}
       run_local_command("docker exec #{container} service sshd restart")
     else
-      run_local_command("docker exec -d #{container} /usr/sbin/sshd -D")
+      run_local_command("docker exec #{container} /usr/sbin/sshd")
     end
   else
     raise "platform #{platform} not yet supported on docker"


### PR DESCRIPTION
This started from a talk on the #testing slack channel, about the docker provisioner not really handling image names that doesn't conform to the form of containing the distribution name as part of the image name and the distribution version as the tag.  This is a show stopper for using the `centos/systemd:latest` image and possibly other internal company images as well.

It also formed around me trying to use podman for running the containers in user space.

The initial attempt just reads the `/etc/os-release` file and parses out the `ID` and `VERSION_ID`.  This is far from perfect, but it is better than splitting the image name and tag apart.  The obvious problems are if the OS is too old to use `/etc/os-release`, like EL6 systems, or for example Debian testing, which currently doesn't have a `VERSION_ID` on that file.

All the facts pulled from `/etc/os-release` is added to the inventoryfile, as facts for the provisioned node.  This could then later be used by other tasks. 

So the question currently standing is:  Which systems is officially supported by this module, and what versions?  The `metadata.json` file doesn't seem up to date/representative, at least regarding versions.  The docker provisioner contains special handling for fixing rpmdb for EL6 (https://github.com/puppetlabs/provision/blob/master/tasks/docker.rb#L19), but EL6 goes end of maintenance support 2 at the end of this year (30 Nov 2020).

I can try and add support for old systems as well, but i need to know which ones.

Another solution could be to use utilize the facts module which is used by the litmus install_agent task to determine which artifacts to fetch, but i guess that would then impose a new dependency on that from provision which might not be desirable.

Fixes #110 