### PR TITLE
Make use of ABS Priority Queuing

### DIFF
--- a/tasks/abs.rb
+++ b/tasks/abs.rb
@@ -22,8 +22,9 @@ def provision(platform, inventory_location)
   job_id = "IAC task PID #{Process.pid}"
 
   headers = { 'X-AUTH-TOKEN' => token_from_fogfile('abs'), 'Content-Type' => 'application/json' }
+  priority = (ENV['CI']) ? 1 : 2
   payload = { 'resources' => { platform => 1 },
-              'priority' => 2,
+              'priority' => priority,
               'job' => { 'id' => job_id,
                          'tags' => { 'user' => Etc.getlogin, 'jenkins_build_url' => jenkins_build_url } } }
 


### PR DESCRIPTION
The ABS API has the ability to set the [priority level](https://github.com/puppetlabs/always-be-scheduling#priority-queuing) of a job. When running in the context of a CI run, we will keep the priority level at 2, however, when running from a manually triggered test run, we'll request priority 1.

Closes: #122 