### PR TITLE
(feat) allow ABS to accept bolt vars

### DIFF
--- a/tasks/abs.json
+++ b/tasks/abs.json
@@ -19,6 +19,10 @@
     "platform": {
       "description": "Platform to provision, eg ubuntu-1604-x86_64",
       "type": "Optional[String[1]]"
+    },
+    "vars": {
+      "description": "key/value pairs to add to the vars section",
+      "type": "Optional[String[1]]"
     }
   },
   "files": [


### PR DESCRIPTION
This is the same as how it works for VMPooler provisioning:
```
➜  joe git:(CISC-611) ✗ bundle exec bolt --modulepath spec/fixtures/modules  plan run joe::demo_01_provision_machines
Bolt may be installed as a gem. To use Bolt reliably and with all of its
dependencies, uninstall the 'bolt' gem and install Bolt as a package:
https://puppet.com/docs/bolt/latest/bolt_installing.html

If you meant to install Bolt as a gem and want to disable this warning,
set the BOLT_GEM environment variable.
Starting: plan joe::demo_01_provision_machines
Starting: task provision::abs on localhost
Finished: task provision::abs with 0 failures in 5.69 sec
Starting: task provision::abs on localhost
Finished: task provision::abs with 0 failures in 5.8 sec
Starting: task provision::abs on localhost
Finished: task provision::abs with 0 failures in 5.71 sec
Starting: task provision::abs on localhost
Finished: task provision::abs with 0 failures in 5.51 sec
Starting: task provision::abs on localhost
Finished: task provision::abs with 0 failures in 5.55 sec
Starting: task provision::abs on localhost
Finished: task provision::abs with 0 failures in 5.5 sec
Starting: task provision::abs on localhost
Finished: task provision::abs with 0 failures in 5.5 sec
Starting: task provision::abs on localhost
Finished: task provision::abs with 0 failures in 5.53 sec
Starting: task provision::abs on localhost
Finished: task provision::abs with 0 failures in 5.46 sec
Starting: task provision::abs on localhost
Finished: task provision::abs with 0 failures in 5.49 sec
Starting: task provision::abs on localhost
Finished: task provision::abs with 0 failures in 5.45 sec
Starting: task provision::abs on localhost
Finished: task provision::abs with 0 failures in 5.46 sec
Finished: plan joe::demo_01_provision_machines in 1 min, 7 sec
Plan completed successfully with no result
➜  joe git:(CISC-611) ✗ cat inventory.yaml
---
version: 2
groups:
- name: docker_nodes
  targets: []
- name: ssh_nodes
  targets:
  - uri: corny-ignition.delivery.puppetlabs.net
    config:
      transport: ssh
      ssh:
        user: root
        password: Qu@lity!
        host-key-check: false
    facts:
      provisioner: abs
      platform: centos-7-x86_64
      job_id: IAC task PID 30848
    vars:
      role: pe
  - uri: ritual-enmity.delivery.puppetlabs.net
    config:
      transport: ssh
      ssh:
        user: root
        password: Qu@lity!
        host-key-check: false
    facts:
      provisioner: abs
      platform: centos-6-x86_64
      job_id: IAC task PID 30875
    vars:
      role: agent_linux
  - uri: untoward-nap.delivery.puppetlabs.net
    config:
      transport: ssh
      ssh:
        user: root
        password: Qu@lity!
        host-key-check: false
    facts:
      provisioner: abs
```