### PR TITLE
(IAC-1229) - Fix for Docker Oracle Linux

### DIFF
--- a/tasks/docker.rb
+++ b/tasks/docker.rb
@@ -15,7 +15,7 @@ def install_ssh_components(distro, version, container)
     run_local_command("docker exec #{container} dnf clean all")
     run_local_command("docker exec #{container} dnf install -y sudo openssh-server openssh-clients")
     run_local_command("docker exec #{container} ssh-keygen -A")
-  when %r{centos}, %r{^el-}, %r{eos}, %r{oracle}, %r{redhat}, %r{scientific}, %r{amzn}
+  when %r{centos}, %r{^el-}, %r{eos}, %r{ol}, %r{redhat}, %r{scientific}, %r{amzn}
     if version == '6'
       # sometimes the redhat 6 variant containers like to eat their rpmdb, leading to
       # issues with "rpmdb: unable to join the environment" errors
@@ -60,7 +60,7 @@ def fix_ssh(distro, version, container)
   case distro
   when %r{debian}, %r{ubuntu}
     run_local_command("docker exec #{container} service ssh restart")
-  when %r{centos}, %r{^el-}, %r{eos}, %r{fedora}, %r{oracle}, %r{redhat}, %r{scientific}, %r{amzn}
+  when %r{centos}, %r{^el-}, %r{eos}, %r{fedora}, %r{ol}, %r{redhat}, %r{scientific}, %r{amzn}
     # Current RedHat/CentOs 7 packs an old version of pam, which are missing a
     # crucial patch when running unprivileged containers.  See:
     # https://bugzilla.redhat.com/show_bug.cgi?id=1728777


### PR DESCRIPTION
As of #112 the way in which the ID for the image is retrieved has been changed causing Oracle Linux's id to be returned as `ol` rather than `oracle`, this is a quick PR to fix it to expect the correct value.