### PR TITLE
(MAINT) Update Docker provisioner image name gsub with '.'

### DIFF
--- a/tasks/docker.rb
+++ b/tasks/docker.rb
@@ -122,7 +122,7 @@ def provision(image, inventory_location, vars)
     break unless stdout.include?(ports)
     raise 'All front facing ports are in use.' if front_facing_port == 2230
   end
-  full_container_name = "#{image.gsub(%r{[/:]}, '_')}-#{front_facing_port}"
+  full_container_name = "#{image.gsub(%r{[\/:\.]}, '_')}-#{front_facing_port}"
   deb_family_systemd_volume = if (image =~ %r{debian|ubuntu}) && (image !~ %r{debian8|ubuntu14})
                                 '--volume /sys/fs/cgroup:/sys/fs/cgroup:ro'
                               else


### PR DESCRIPTION
### Description

When attempting to provision an image from a repository with a `/`
in the name (e.g. registry.suse.com), the provisioning will fail
because docker does not support `.`s in the image name.

This change updates the `gsub` call in the image name construction
to also substitute out `.`.

We should also be escaping the `/` character too - fixes that too

### Testing

- [x] `bundle exec rake 'litmus:provision[docker, registry.suse.com/suse/sle15:latest]'` successfully executes
- [x] `bundle exec rake 'litmus:provision[docker, litmusimage/centos:7]'` successfully executes (_regression test_)