### PR TITLE
(feat) Allow for passing docker runtime options

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ Simple tasks to provision and tear_down containers / instances and virtual machi
 
 Bolt tasks allowing a user to provision and tear down systems. It also maintains a Bolt inventory file.
 Provisioners so far:
-   
+
 * ABS (AlwaysBeScheduling)
 * Docker
 * Vagrant
@@ -143,6 +143,12 @@ Finished on localhost:
   }
 Successful on 1 node: localhost
 Ran on 1 node in 33.96 seconds
+```
+
+Provision allows for passing additional command line arguments to the docker run when specifying `vars['docker_run_opts']` as an array of arguments.
+
+```
+$ bundle exec bolt --modulepath /Users/tp/workspace/git/ task run provision::docker --targets localhost  action=provision platform=ubuntu:14.04 inventory=/Users/tp/workspace/git/provision vars='{ "docker_run_opts": ["-p 8086:8086", "-p 3000:3000"]}'
 ```
 
 tear_down

--- a/README.md
+++ b/README.md
@@ -99,7 +99,7 @@ $ cat ~/.fog
 ##### Setting up a new macine
 
 ```
-$ bundle exec bolt --modulepath /Users/tp/workspace/git/ task run provision::abs --nodes localhost action=provision platform=ubuntu-1604-x86_64 inventory=/Users/tp/workspace/git/provision
+$ bundle exec bolt --modulepath /Users/tp/workspace/git/ task run provision::abs --targets localhost action=provision platform=ubuntu-1604-x86_64 inventory=/Users/tp/workspace/git/provision
 
 Started on localhost...
 Finished on localhost:
@@ -114,7 +114,7 @@ Ran on 1 node in 1.44 seconds
 ##### Tearing down a finished machine
 
 ```
-$ bundle exec bolt --modulepath /Users/tp/workspace/git/ task run provision::abs --nodes localhost  action=tear_down inventory=/Users/tp/workspace/git/provision node_name=yh6f4djvz7o3te6.delivery.puppetlabs.net
+$ bundle exec bolt --modulepath /Users/tp/workspace/git/ task run provision::abs --targets localhost  action=tear_down inventory=/Users/tp/workspace/git/provision node_name=yh6f4djvz7o3te6.delivery.puppetlabs.net
 
 Started on localhost...
 Finished on localhost:
@@ -133,7 +133,7 @@ Given an docker image name it will spin up that container and setup external ssh
 provision
 
 ```
-$ bundle exec bolt --modulepath /Users/tp/workspace/git/ task run provision::docker --nodes localhost  action=provision platform=ubuntu:14.04 inventory=/Users/tp/workspace/git/provision
+$ bundle exec bolt --modulepath /Users/tp/workspace/git/ task run provision::docker --targets localhost  action=provision platform=ubuntu:14.04 inventory=/Users/tp/workspace/git/provision
 
 Started on localhost...
 Finished on localhost:
@@ -154,7 +154,7 @@ $ bundle exec bolt --modulepath /Users/tp/workspace/git/ task run provision::doc
 tear_down
 
 ```
-$ bundle exec bolt --modulepath /Users/tp/workspace/git/ task run provision::docker --nodes localhost  action=tear_down inventory=/Users/tp/workspace/git/provision node_name=localhost:2222
+$ bundle exec bolt --modulepath /Users/tp/workspace/git/ task run provision::docker --targets localhost  action=tear_down inventory=/Users/tp/workspace/git/provision node_name=localhost:2222
 
 Started on localhost...
 Finished on localhost:
@@ -178,7 +178,7 @@ Tested with vagrant images:
 provision
 
 ```
-$ bundle exec bolt --modulepath /Users/tp/workspace/git/ task run provision::vagrant --nodes localhost  action=provision platform=ubuntu/xenial64 inventory=/Users/tp/workspace/git/provision
+$ bundle exec bolt --modulepath /Users/tp/workspace/git/ task run provision::vagrant --targets localhost  action=provision platform=ubuntu/xenial64 inventory=/Users/tp/workspace/git/provision
 
 Started on localhost...
 Finished on localhost:
@@ -209,7 +209,7 @@ Ran on 1 target in 0.84 sec
 
 tear_down
 ```
-$ bundle exec bolt --modulepath /Users/tp/workspace/git/ task run provision::vagrant --nodes localhost  action=tear_down inventory=/Users/tp/workspace/git/provision node_name=127.0.0.1:2222
+$ bundle exec bolt --modulepath /Users/tp/workspace/git/ task run provision::vagrant --targets localhost  action=tear_down inventory=/Users/tp/workspace/git/provision node_name=127.0.0.1:2222
 
 Started on localhost...
 Finished on localhost:
@@ -242,7 +242,7 @@ In the provision step you can invoke bundle exec rake 'litmus:provision_list[tes
 
 Manual invokation of the provision service task from a workflow can be done using:
 ```
-bundle exec bolt --modulepath /Users/tp/workspace/git/ task run provision::provision_service --nodes localhost  action=provision platform=centos-7-v20200813 inventory=/Users/tp/workspace/git/provision
+bundle exec bolt --modulepath /Users/tp/workspace/git/ task run provision::provision_service --targets localhost  action=provision platform=centos-7-v20200813 inventory=/Users/tp/workspace/git/provision
 ```
 Or using Litmus:
 
@@ -277,7 +277,7 @@ provision
 
 ```
 PS> $env:LITMUS_HYPERV_VSWITCH = 'internal_nat'
-PS> bundle exec bolt --modulepath /Users/tp/workspace/git/ task run provision::vagrant --nodes localhost  action=provision platform=centos/7 inventory=/Users/tp/workspace/git/provision hyperv_smb_username=tp hyperv_smb_password=notMyrealPassword
+PS> bundle exec bolt --modulepath /Users/tp/workspace/git/ task run provision::vagrant --targets localhost  action=provision platform=centos/7 inventory=/Users/tp/workspace/git/provision hyperv_smb_username=tp hyperv_smb_password=notMyrealPassword
 
 Started on localhost...
 Finished on localhost:
@@ -305,7 +305,7 @@ export VMPOOLER_HOSTNAME=vcloud.delivery.puppetlabs.net
 provision
 
 ```
-$ bundle exec bolt --modulepath /Users/tp/workspace/git/ task run provision::vmpooler --nodes localhost  action=provision platform=ubuntu-1604-x86_64 inventory=/Users/tp/workspace/git/provision
+$ bundle exec bolt --modulepath /Users/tp/workspace/git/ task run provision::vmpooler --targets localhost  action=provision platform=ubuntu-1604-x86_64 inventory=/Users/tp/workspace/git/provision
 
 Started on localhost...
 Finished on localhost:
@@ -320,7 +320,7 @@ Ran on 1 node in 1.46 seconds
 tear_down
 
 ```
-$ bundle exec bolt --modulepath /Users/tp/workspace/git/ task run provision::vmpooler --nodes localhost  action=tear_down inventory=/Users/tp/workspace/git/provision node_name=gffzr8c3gipetkp.delivery.puppetlabs.net
+$ bundle exec bolt --modulepath /Users/tp/workspace/git/ task run provision::vmpooler --targets localhost  action=tear_down inventory=/Users/tp/workspace/git/provision node_name=gffzr8c3gipetkp.delivery.puppetlabs.net
 Started on localhost...
 Finished on localhost:
   Removed gffzr8c3gipetkp.delivery.puppetlabs.net
@@ -351,5 +351,5 @@ Testing/development/debugging it is better to use ruby directly, you will need t
 
 Testing using bolt, the second step
 ```
-$ bundle exec bolt --modulepath /Users/tp/workspace/git/ task run provision::docker --nodes localhost  action=provision platform=ubuntu:14.04 inventory=/Users/tp/workspace/git/provision
+$ bundle exec bolt --modulepath /Users/tp/workspace/git/ task run provision::docker --targets localhost  action=provision platform=ubuntu:14.04 inventory=/Users/tp/workspace/git/provision
 ```


### PR DESCRIPTION
Prior to this PR, there was no way to pass command-line arguments to
the docker run command in the docker provisioner. This PR adds the
ability to pass arguments to the docker run command through the existing
vars parameter. This PR resolves #142 

It also includes a small readme update to replace `--nodes` with `--targets`. Let me know if you would prefer this in a separate PR.

An example of this is below. 

```
$ bolt --modulepath .. task run provision::docker --targets localhost action=provision platform=litmusimage/centos:7 inventory=. vars='{ "docker_run_opts": ["-p 8086:8086", "-p 3000:3000"]}'
Started on localhost...
Finished on localhost:
  { 
    "status": "ok",
    "node_name": "localhost:2223",
    "node": {
      "uri": "localhost:2223",
      "config": {
        "transport": "ssh",
        "ssh": {
          "user": "root",
          "password": "root",
          "port": 2223,
          "host-key-check": false
        }
      },
      "facts": {
        "provisioner": "docker",
        "container_name": "litmusimage_centos_7-2223",
        "platform": "litmusimage/centos:7",
        "os-release": {
          "NAME": "CentOS Linux",
          "VERSION": "7 (Core)",
          "ID": "centos",
          "ID_LIKE": "rhel fedora",
          "VERSION_ID": "7",
          "PRETTY_NAME": "CentOS Linux 7 (Core)",
          "ANSI_COLOR": "0;31",
          "CPE_NAME": "cpe:/o:centos:centos:7",
          "HOME_URL": "https://www.centos.org/",
          "BUG_REPORT_URL": "https://bugs.centos.org/",
          "CENTOS_MANTISBT_PROJECT": "CentOS-7",
          "CENTOS_MANTISBT_PROJECT_VERSION": "7",
          "REDHAT_SUPPORT_PRODUCT": "centos",
          "REDHAT_SUPPORT_PRODUCT_VERSION": "7"
        }
      },
      "vars": {
        "docker_run_opts": [
          "-p 8086:8086",
          "-p 3000:3000"
        ]
      }
    }
  }
Successful on 1 target: localhost
Ran on 1 target in 18.64 sec
```