### PR TITLE
Fix typo from rubocop fixes in docker provisioner

### DIFF
--- a/tasks/docker.rb
+++ b/tasks/docker.rb
@@ -31,8 +31,8 @@ def install_ssh_components(distro, version, container)
       run_local_command("docker exec #{container} yum install -y sudo openssh-server openssh-clients")
     end
     ssh_folder = run_local_command("docker exec #{container} ls /etc/ssh/")
-    run_local_command("docker exec #{container} ssh-keygen -t rsa -f /etc/ssh/ssh_host_rsa_key -N \"\"") unless ssh_folder.include?(%r{ssh_host_rsa_key})
-    run_local_command("docker exec #{container} ssh-keygen -t dsa -f /etc/ssh/ssh_host_dsa_key -N \"\"") unless ssh_folder.include?(%r{ssh_host_dsa_key})
+    run_local_command("docker exec #{container} ssh-keygen -t rsa -f /etc/ssh/ssh_host_rsa_key -N \"\"") unless ssh_folder.include?('ssh_host_rsa_key')
+    run_local_command("docker exec #{container} ssh-keygen -t dsa -f /etc/ssh/ssh_host_dsa_key -N \"\"") unless ssh_folder.include?('ssh_host_dsa_key')
   when %r{opensuse}, %r{sles}
     run_local_command("docker exec #{container} zypper -n in openssh")
     run_local_command("docker exec #{container} ssh-keygen -t rsa -f /etc/ssh/ssh_host_rsa_key")


### PR DESCRIPTION
`include?` takes only strings, not regex

This addresses the failure in https://travis-ci.com/github/puppetlabs/puppet_litmus/jobs/462473050#L1535