### PR TITLE
(CISC-973) Handle vars in gcp provisioner

### DIFF
--- a/tasks/provision_service.rb
+++ b/tasks/provision_service.rb
@@ -98,10 +98,8 @@ def provision(platform, inventory_location, vars)
   unless vars.nil?
     var_hash = YAML.safe_load(vars)
     response_hash['groups'].each do |bg|
-      bg['targets'].each do |trgt|
-        trgt['uri'].each do |ur|
-          ur['vars'] = var_hash
-        end
+      bg['targets'].each do |trgts|
+        trgts['vars'] = var_hash
       end
     end
   end

--- a/tasks/provision_service.rb
+++ b/tasks/provision_service.rb
@@ -119,7 +119,7 @@ def provision(platform, inventory_location, vars)
     File.open(inventory_full_path, 'w') { |f| f.write inventory_hash.to_yaml }
   else
     File.open('inventory.yaml', 'wb') do |f|
-      f.write(response_hash)
+      f.write(YAML.dump(response_hash))
     end
   end
 


### PR DESCRIPTION
This work is to allow the addiiton of 'vars' into the inventory file for gcp provisioning, as required by comply. Tested against https://github.com/puppetlabs/comply/runs/1656251077?check_suite_focus=true with the following result:

Run cat ./inventory.yaml
```
---
version: 2
groups:
- name: docker_nodes
  targets: []
- name: ssh_nodes
  targets:
  - uri: 104.155.47.124
    config:
      transport: ssh
      ssh:
        user: litmuskww5w1fm
        password: ******************
        host-key-check: false
        port: 22
        run-as: root
    facts:
      provisioner: provision::provision_service
      platform: centos-7
      uuid: 197d8ae6-027f-4b5f-b4c9-1509dffd0e5a
    vars:
      role: pe
  - uri: 34.76.79.34
    config:
      transport: ssh
      ssh:
        user: litmusiyvs9lpg
        password: ****************
        host-key-check: false
        port: 22
        run-as: root
    facts:
      provisioner: provision::provision_service
      platform: centos-7
      uuid: 6a4f6c84-d33a-4e71-98b2-fe945776e24b
    vars:
      role: comply
```