### PR TITLE
(maint) Update default PE to 2019.8

### DIFF
--- a/tasks/install_pe.sh
+++ b/tasks/install_pe.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 if [ -z ${PT_version+x} ]; then
-  PE_RELEASE=2019.3
+  PE_RELEASE=2019.8
 
 else
   PE_RELEASE=$PT_version
@@ -27,7 +27,7 @@ if [[ $? -ne 0 ]];then
 fi
 
 cd ${PE_FILE_NAME}
-DISABLE_ANALYTICS=1 ./puppet-enterprise-installer
+DISABLE_ANALYTICS=1 ./puppet-enterprise-installer -y -c ./conf.d/pe.conf
 if [[ $? -ne 0 ]];then
  echo “Error: Failed to install Puppet Enterprise. Please check the logs and call Bryan.x ”
  exit 2


### PR DESCRIPTION
2019.8 console is significantly different from 2019.3

`-y -c ./conf.d/pe.conf` added so that PE installs unattended and with provided defaults
