### PR TITLE
(GH-380) Moving inventory.yaml to /spec/fixtures/litmus_inventory.yaml

### DIFF
--- a/tasks/abs.rb
+++ b/tasks/abs.rb
@@ -68,7 +68,7 @@ def provision(platform, inventory_location, vars)
 
   raise 'Timeout: unable to get a 200 response in 10 minutes' if reply.code != '200'
 
-  inventory_full_path = File.join(inventory_location, 'inventory.yaml')
+  inventory_full_path = File.join(inventory_location, '/spec/fixtures/litmus_inventory.yaml')
   inventory_hash = get_inventory_hash(inventory_full_path)
   data = JSON.parse(reply.body)
   data.each do |host|
@@ -96,8 +96,7 @@ end
 
 def tear_down(node_name, inventory_location)
   include PuppetLitmus::InventoryManipulation
-
-  inventory_full_path = File.join(inventory_location, 'inventory.yaml')
+  inventory_full_path = File.join(inventory_location, '/spec/fixtures/litmus_inventory.yaml')
   if File.file?(inventory_full_path)
     inventory_hash = inventory_hash_from_inventory_file(inventory_full_path)
     facts = facts_from_node(inventory_hash, node_name)

--- a/tasks/docker.rb
+++ b/tasks/docker.rb
@@ -109,7 +109,7 @@ end
 
 def provision(image, inventory_location, vars)
   include PuppetLitmus::InventoryManipulation
-  inventory_full_path = File.join(inventory_location, 'inventory.yaml')
+  inventory_full_path = File.join(inventory_location, '/spec/fixtures/litmus_inventory.yaml')
   inventory_hash = get_inventory_hash(inventory_full_path)
   os_release_facts = get_image_os_release_facts(image)
   distro = os_release_facts['ID']
@@ -163,7 +163,7 @@ end
 
 def tear_down(node_name, inventory_location)
   include PuppetLitmus::InventoryManipulation
-  inventory_full_path = File.join(inventory_location, 'inventory.yaml')
+  inventory_full_path = File.join(inventory_location, '/spec/fixtures/litmus_inventory.yaml')
   raise "Unable to find '#{inventory_full_path}'" unless File.file?(inventory_full_path)
   inventory_hash = inventory_hash_from_inventory_file(inventory_full_path)
   node_facts = facts_from_node(inventory_hash, node_name)

--- a/tasks/docker_exp.rb
+++ b/tasks/docker_exp.rb
@@ -11,7 +11,7 @@ require_relative '../lib/task_helper'
 
 def provision(docker_platform, inventory_location, vars)
   include PuppetLitmus::InventoryManipulation
-  inventory_full_path = File.join(inventory_location, 'inventory.yaml')
+  inventory_full_path = File.join(inventory_location, '/spec/fixtures/litmus_inventory.yaml')
   inventory_hash = get_inventory_hash(inventory_full_path)
   unless vars.nil?
     var_hash = YAML.safe_load(vars)
@@ -41,7 +41,7 @@ end
 
 def tear_down(node_name, inventory_location)
   include PuppetLitmus::InventoryManipulation
-  inventory_full_path = File.join(inventory_location, 'inventory.yaml')
+  inventory_full_path = File.join(inventory_location, '/spec/fixtures/litmus_inventory.yaml')
   raise "Unable to find '#{inventory_full_path}'" unless File.file?(inventory_full_path)
   inventory_hash = inventory_hash_from_inventory_file(inventory_full_path)
   node_facts = facts_from_node(inventory_hash, node_name)

--- a/tasks/provision_service.rb
+++ b/tasks/provision_service.rb
@@ -89,7 +89,7 @@ def provision(platform, inventory_location, vars)
     data = JSON.parse(vars.tr(';', ','))
     job_url = data['job_url']
   end
-  inventory_full_path = File.join(inventory_location, 'inventory.yaml')
+  inventory_full_path = File.join(inventory_location, '/spec/fixtures/litmus_inventory.yaml')
 
   params = platform_to_cloud_request_parameters(platform, cloud, region, zone)
   response = invoke_cloud_request(params, uri, job_url, 'post')
@@ -113,10 +113,10 @@ def provision(platform, inventory_location, vars)
         end
       end
     end
-
     File.open(inventory_full_path, 'w') { |f| f.write inventory_hash.to_yaml }
   else
-    File.open('inventory.yaml', 'wb') do |f|
+    FileUtils.mkdir_p(File.join(Dir.pwd, '/spec/fixtures'))
+    File.open(inventory_full_path, 'wb') do |f|
       f.write(YAML.dump(response_hash))
     end
   end
@@ -132,7 +132,7 @@ def tear_down(platform, inventory_location, _vars)
   # remove all provisioned resources
   uri = URI.parse(ENV['SERVICE_URL'] || default_uri)
 
-  inventory_full_path = File.join(inventory_location, 'inventory.yaml')
+  inventory_full_path = File.join(inventory_location, '/spec/fixtures/litmus_inventory.yaml')
   # rubocop:disable Style/GuardClause
   if File.file?(inventory_full_path)
     inventory_hash = inventory_hash_from_inventory_file(inventory_full_path)

--- a/tasks/vagrant.rb
+++ b/tasks/vagrant.rb
@@ -115,7 +115,7 @@ def provision(platform, inventory_location, enable_synced_folder, provider, cpus
   end
 
   include PuppetLitmus
-  inventory_full_path = File.join(inventory_location, 'inventory.yaml')
+  inventory_full_path = File.join(inventory_location, '/spec/fixtures/litmus_inventory.yaml')
   inventory_hash = get_inventory_hash(inventory_full_path)
   vagrant_dirs = Dir.glob("#{File.join(inventory_location, '.vagrant')}/*/").map { |d| File.basename(d) }
   @vagrant_env = File.expand_path(File.join(inventory_location, '.vagrant', get_vagrant_dir(platform, vagrant_dirs)))
@@ -181,7 +181,7 @@ end
 def tear_down(node_name, inventory_location)
   include PuppetLitmus
   command = 'vagrant destroy -f'
-  inventory_full_path = File.join(inventory_location, 'inventory.yaml')
+  inventory_full_path = File.join(inventory_location, '/spec/fixtures/litmus_inventory.yaml')
   if File.file?(inventory_full_path)
     inventory_hash = inventory_hash_from_inventory_file(inventory_full_path)
     vagrant_env = facts_from_node(inventory_hash, node_name)['vagrant_env']


### PR DESCRIPTION
- Renaming the inventory.yaml file to litmus_inventory.yaml
- Relocating file from the module root directory to /spec/fixtures/
- Removal of vmpooler as it is deprecated

The point in this change is to avoid running tests on a live production system by accident.

This piece of work includes changes in multiple places. 

1. pdk-templates: https://github.com/puppetlabs/pdk-templates/pull/414
2. puppet_litmus: https://github.com/puppetlabs/puppet_litmus/pull/396
3. provision module: https://github.com/puppetlabs/provision/pull/161

The follow PR is testing out my changes: https://github.com/puppetlabs/puppetlabs-testing/pull/353
