### PR TITLE
(REPLATS-169) Add a timestamp to abs job_id

### DIFF
--- a/tasks/abs.rb
+++ b/tasks/abs.rb
@@ -6,6 +6,7 @@ require 'net/http'
 require 'yaml'
 require 'puppet_litmus'
 require 'etc'
+require 'date'
 require_relative '../lib/task_helper'
 
 def provision(platform, inventory_location, vars)
@@ -21,7 +22,7 @@ def provision(platform, inventory_location, vars)
                         'https://litmus_manual'
                       end
   # Job ID must be unique
-  job_id = "iac-task-pid-#{Process.pid}"
+  job_id = "iac-task-pid-#{Process.pid}-#{DateTime.now.strftime('%Q')}"
 
   headers = { 'X-AUTH-TOKEN' => token_from_fogfile('abs'), 'Content-Type' => 'application/json' }
   priority = (ENV['CI']) ? 1 : 2


### PR DESCRIPTION
Was running into a problem where ABS was returning 404s that looked to
trace back to errors like:

  Failed to allocate resources: Error ("OndemandVmpoolerAllocator Could
  not allocate VMs because of a conflict: request_id 'iac-task-pid-496'
  has already been created 409 Conflict") encountered while allocating
  resources from
  https://vmpooler-cinext.delivery.puppetlabs.net/api/v1/ondemandvm with
  request [{"centos-8.3-kurl-beta-x86_64":1,"r
  equest_id":"iac-task-pid-496"}]

Samuel's guess was that the issue was tripping over duplicate process
ids from previous runs. Adding timestamp to the submitted job_id to
avoid that.