### PR TITLE
(feat) Add ssh key support to abs ssh transport

### DIFF
--- a/tasks/abs.rb
+++ b/tasks/abs.rb
@@ -75,8 +75,13 @@ def provision(platform, inventory_location, vars)
   data.each do |host|
     if platform_uses_ssh(host['type'])
       node = { 'uri' => host['hostname'],
-               'config' => { 'transport' => 'ssh', 'ssh' => { 'user' => ENV['ABS_USER'], 'password' => ENV['ABS_PASSWORD'], 'host-key-check' => false } },
+               'config' => { 'transport' => 'ssh', 'ssh' => { 'user' => ENV['ABS_USER'], 'host-key-check' => false } },
                'facts' => { 'provisioner' => 'abs', 'platform' => host['type'], 'job_id' => job_id } }
+      if !ENV['ABS_SSH_PRIVATE_KEY'].empty?
+        node['config']['ssh']['private-key'] = ENV['ABS_SSH_PRIVATE_KEY']
+      else
+        node['config']['ssh']['password'] = ENV['ABS_PASSWORD']
+      end
       group_name = 'ssh_nodes'
     else
       node = { 'uri' => host['hostname'],


### PR DESCRIPTION
Allows for an ABS_SSH_PRIVATE_KEY env variable to provide a path to a
local private key for the inventory ssh config rather than a password
credential. Prefers ABS_SSH_PRIVATE_KEY if present.

This allows us to use ssh keys to reach abs hosts in CI.

I've been testing with my branch here:

https://github.com/puppetlabs/kurl_test/pull/47/files#diff-e6ffa5dc854b843b3ee3c3c28f8eae2f436c2df2b1ca299cca1fa5982e390cf8R36