### PR TITLE
(maint) Change references to facter_task to be provision

### DIFF
--- a/tasks/abs.rb
+++ b/tasks/abs.rb
@@ -160,6 +160,6 @@ begin
   puts result.to_json
   exit 0
 rescue => e
-  puts({ _error: { kind: 'facter_task/failure', msg: e.message } }.to_json)
+  puts({ _error: { kind: 'provision/abs_failure', msg: e.message } }.to_json)
   exit 1
 end

--- a/tasks/docker_exp.rb
+++ b/tasks/docker_exp.rb
@@ -78,6 +78,6 @@ begin
   puts result.to_json
   exit 0
 rescue => e
-  puts({ _error: { kind: 'facter_task/failure', msg: e.message } }.to_json)
+  puts({ _error: { kind: 'provision/docker_exp_failure', msg: e.message } }.to_json)
   exit 1
 end


### PR DESCRIPTION
There were two error messages in the abs and docker_exp that probably
had a copy/pasted reference to facter_task/failure. Changed them to be
provision specific so it's clear when getting errors from one of the
tasks that it's coming from provision.