### PR TITLE
Remove deb_family_systemd_volume from docker_exp

### DIFF
--- a/tasks/docker_exp.rb
+++ b/tasks/docker_exp.rb
@@ -18,12 +18,7 @@ def provision(docker_platform, inventory_location, vars)
     docker_run_opts = var_hash['docker_run_opts'].flatten.join(' ') unless var_hash['docker_run_opts'].nil?
   end
 
-  deb_family_systemd_volume = if (docker_platform =~ %r{debian|ubuntu}) && (docker_platform !~ %r{debian8|ubuntu14})
-                                '--volume /sys/fs/cgroup:/sys/fs/cgroup:ro'
-                              else
-                                ''
-                              end
-  creation_command = "docker run -d -it #{deb_family_systemd_volume} --privileged #{docker_run_opts} #{docker_platform}"
+  creation_command = "docker run -d -it --privileged #{docker_run_opts} #{docker_platform}"
   container_id = run_local_command(creation_command).strip[0..11]
   fix_missing_tty_error_message(container_id) unless platform_is_windows?(docker_platform)
   node = { 'uri' => container_id,


### PR DESCRIPTION
The `deb_family_systemd_volume` logic hardcoded a
`--volume /sys/fs/cgroup:/sys/fs/cgroup:ro` flag when provisioning
Debian or Ubuntu containers in order to allow SystemD to run.

However, this mount is no longer sufficient when the docker host
is running a Kernel with CGroupsV2 and a SystemD version that defaults
to using `systemd.enableUnifiedCgroupHierarchy=true`:

  https://github.com/docker/for-mac/issues/6073

Ubuntu 22.04 fits these criteria.

In these conditions, `--cgroupns=host -v /sys/fs/cgroup:/sys/fs/cgroup:rw`
must be used. However, attempting to pass these flags to `docker_exp`
via `docker_run_opts` causes `docker run` to fail due to a conflict
with the hardcoded mount from `deb_family_systemd_volume`:

```
stderr:docker: Error response from daemon: Duplicate mount point: /sys/fs/cgroup.
```

This commit removes the `deb_family_systemd_volume` logic as:

 - CGroup mounts must be configured for any OS family using SystemD, not
   just Debian and Ubuntu.

 - The user should be able to exercise full control over mount flags
   via `docker_run_opts`.