### PR TITLE
(CONT-941) Add release workflows

### DIFF
--- a/.github/workflows/auto_release.yml
+++ b/.github/workflows/auto_release.yml
@@ -1,0 +1,9 @@
+name: "Auto release"
+
+on:
+  workflow_dispatch:
+
+jobs:
+  release_prep:
+    uses: "puppetlabs/cat-github-actions/.github/workflows/module_release_prep.yml@main"
+    secrets: "inherit"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,35 @@
+name: "Module Release"
+
+on:
+  workflow_call:
+
+jobs:
+  release:
+    name: "Release"
+    runs-on: "ubuntu-latest"
+    if: github.repository_owner == 'puppetlabs'
+
+    steps:
+
+      - name: "Checkout"
+        uses: "actions/checkout@v3"
+        with:
+          ref: "${{ github.ref }}"
+          clean: true
+          fetch-depth: 0
+
+      - name: "Get version"
+        id: "get_version"
+        run: |
+          echo "version=$(jq --raw-output .version metadata.json)" >> $GITHUB_OUTPUT
+
+      - name: "PDK build"
+        uses: "docker://puppet/pdk:nightly"
+        with:
+          args: "build"
+
+      - name: "Create release"
+        run: |
+          gh release create v${{ steps.get_version.outputs.version }} --title v${{ steps.get_version.outputs.version }}
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
Prior to this commit, provision didn't have the release_prep or release workflows. This commit adds them.