### PR TITLE
(MAINT) Support Puppet 8

### DIFF
--- a/tasks/install_puppetserver.sh
+++ b/tasks/install_puppetserver.sh
@@ -162,7 +162,7 @@ if [[ "$osfamily" == "debian" ]]; then
 fi
 
 if [[ "$osfamily" == "redhat" ]]; then
-  run_cmd "curl -o puppet.rpm http://yum.puppetlabs.com/${collection}/${collection}-release-el-${major_version}.noarch.rpm"
+  run_cmd "curl -o puppet.rpm http://yum.puppetlabs.com/${collection}-release-el-${major_version}.noarch.rpm"
   rpm -Uvh puppet.rpm --quiet
   yum install puppetserver -y --quiet
 fi


### PR DESCRIPTION
This commit switches the RPM URL to pull from the top level link, as Puppet 8 does not have a convenience link located in the `puppet8` dir.