### PR TITLE
(CONT-954) Pin changelog generator to 1.15.2

### DIFF
--- a/.sync.yml
+++ b/.sync.yml
@@ -10,7 +10,11 @@
 appveyor.yml:
   delete: true
 Gemfile:
-  unmanaged: true
+  optional:
+    ":development":
+    - gem: github_changelog_generator
+      version: '= 1.15.2'
+    - gem: webmock
 Rakefile:
   changelog_project: provision
 spec/spec_helper.rb:

--- a/Gemfile
+++ b/Gemfile
@@ -19,7 +19,6 @@ group :development do
   gem "json", '= 2.5.1',                         require: false if Gem::Requirement.create(['>= 3.0.0', '< 3.0.5']).satisfied_by?(Gem::Version.new(RUBY_VERSION.dup))
   gem "json", '= 2.6.1',                         require: false if Gem::Requirement.create(['>= 3.1.0', '< 3.1.3']).satisfied_by?(Gem::Version.new(RUBY_VERSION.dup))
   gem "json", '= 2.6.3',                         require: false if Gem::Requirement.create(['>= 3.2.0', '< 4.0.0']).satisfied_by?(Gem::Version.new(RUBY_VERSION.dup))
-  gem 'github_changelog_generator',              require: false if Gem::Version.new(RUBY_VERSION.dup) >= Gem::Version.new('2.5.0')
   gem "voxpupuli-puppet-lint-plugins", '~> 5.0', require: false
   gem "facterdb", '~> 1.18',                     require: false
   gem "metadata-json-lint", '~> 3.0',            require: false
@@ -35,7 +34,8 @@ group :development do
   gem "rubocop-performance", '= 1.16.0',         require: false
   gem "rubocop-rspec", '= 2.19.0',               require: false
   gem "rb-readline", '= 0.5.5',                  require: false, platforms: [:mswin, :mingw, :x64_mingw]
-  gem 'webmock'
+  gem "github_changelog_generator", '= 1.15.2',  require: false
+  gem "webmock",                                 require: false
 end
 group :system_tests do
   gem "puppet_litmus", '~> 1.0', require: false, platforms: [:ruby, :x64_mingw]

--- a/Rakefile
+++ b/Rakefile
@@ -42,6 +42,7 @@ end
 
 PuppetLint.configuration.send('disable_relative')
 
+
 if Bundler.rubygems.find_name('github_changelog_generator').any?
   GitHubChangelogGenerator::RakeTask.new :changelog do |config|
     raise "Set CHANGELOG_GITHUB_TOKEN environment variable eg 'export CHANGELOG_GITHUB_TOKEN=valid_token_here'" if Rake.application.top_level_tasks.include? "changelog" and ENV['CHANGELOG_GITHUB_TOKEN'].nil?


### PR DESCRIPTION
Prior to this commit, the release prep workflow intorduced was failing due to an incorrect version of the changelog generator. This commit pins it in the sync.yml and a pdk update was run.