### PR TITLE
(maint) - Add connect-timeout to transport

### DIFF
--- a/tasks/abs.rb
+++ b/tasks/abs.rb
@@ -91,7 +91,7 @@ class ABSProvision
     data.each do |host|
       if platform_uses_ssh(host['type'])
         node = { 'uri' => host['hostname'],
-                 'config' => { 'transport' => 'ssh', 'ssh' => { 'user' => ENV['ABS_USER'], 'host-key-check' => false } },
+                 'config' => { 'transport' => 'ssh', 'ssh' => { 'user' => ENV['ABS_USER'], 'host-key-check' => false, 'connect-timeout' => 120 } },
                  'facts' => { 'provisioner' => 'abs', 'platform' => host['type'], 'job_id' => job_id } }
         if !ENV['ABS_SSH_PRIVATE_KEY'].nil? && !ENV['ABS_SSH_PRIVATE_KEY'].empty?
           node['config']['ssh']['private-key'] = ENV['ABS_SSH_PRIVATE_KEY']
@@ -101,7 +101,7 @@ class ABSProvision
         group_name = 'ssh_nodes'
       else
         node = { 'uri' => host['hostname'],
-                 'config' => { 'transport' => 'winrm', 'winrm' => { 'user' => ENV['ABS_WIN_USER'], 'password' => ENV['ABS_PASSWORD'], 'ssl' => false } },
+                 'config' => { 'transport' => 'winrm', 'winrm' => { 'user' => ENV['ABS_WIN_USER'], 'password' => ENV['ABS_PASSWORD'], 'ssl' => false, 'connect-timeout' => 120 } },
                  'facts' => { 'provisioner' => 'abs', 'platform' => host['type'], 'job_id' => job_id } }
         group_name = 'winrm_nodes'
       end

--- a/tasks/docker.rb
+++ b/tasks/docker.rb
@@ -162,7 +162,7 @@ def provision(image, inventory_location, vars)
     'uri' => "#{hostname}:#{front_facing_port}",
     'config' => {
       'transport' => 'ssh',
-      'ssh' => { 'user' => 'root', 'password' => 'root', 'port' => front_facing_port, 'host-key-check' => false }
+      'ssh' => { 'user' => 'root', 'password' => 'root', 'port' => front_facing_port, 'host-key-check' => false, 'connect-timeout' => 120 }
     },
     'facts' => {
       'provisioner' => 'docker',

--- a/tasks/docker_exp.rb
+++ b/tasks/docker_exp.rb
@@ -29,7 +29,7 @@ def provision(docker_platform, inventory_location, vars)
   container_id = run_local_command(creation_command).strip[0..11]
   fix_missing_tty_error_message(container_id) unless platform_is_windows?(docker_platform)
   node = { 'uri' => container_id,
-           'config' => { 'transport' => 'docker', 'docker' => { 'shell-command' => @shell_command } },
+           'config' => { 'transport' => 'docker', 'docker' => { 'shell-command' => @shell_command, 'connect-timeout' => 120 } },
            'facts' => { 'provisioner' => 'docker_exp', 'container_id' => container_id, 'platform' => docker_platform } }
   unless vars.nil?
     var_hash = YAML.safe_load(vars)

--- a/tasks/vagrant.rb
+++ b/tasks/vagrant.rb
@@ -150,7 +150,8 @@ def provision(platform, inventory_location, enable_synced_folder, provider, cpus
           'host' => remote_config['hostname'],
           'host-key-check' => remote_config['stricthostkeychecking'],
           'port' => remote_config['port'],
-          'run-as' => 'root'
+          'run-as' => 'root',
+          'connect-timeout' => 120
         }
       },
       'facts' => {
@@ -173,7 +174,8 @@ def provision(platform, inventory_location, enable_synced_folder, provider, cpus
         'winrm' => {
           'user' => remote_config['user'],
           'password' => remote_config['password'],
-          'ssl' => remote_config['uses_ssl']
+          'ssl' => remote_config['uses_ssl'],
+          'connect-timeout' => 120
         }
       },
       'facts' => {


### PR DESCRIPTION
This PR adds a `connect-timeout` flag to each provisioned node in the litmus_inventory, to help prevent transient timeout errors during testing.

Initially, this defaulted to 10s which caused numerous false errors due to timeouts, this increases the default to 2 minutes.

_note - machines provisioned with the provision_service will be updated in a separate PR in [provision_service](https://github.com/puppetlabs/provision_service)_