### PR TITLE
(CAT-1253) - Fixes undefined variable in vagrant provisioner

### DIFF
--- a/tasks/vagrant.rb
+++ b/tasks/vagrant.rb
@@ -70,7 +70,7 @@ def generate_vagrantfile(file_path, platform, enable_synced_folder, provider, cp
 end
 
 def get_vagrant_dir(platform, vagrant_dirs, int = 0)
-  platform_dir = "#{platform}-#{i}".gsub(%r{[/\\]}, '-') # Strip slashes
+  platform_dir = "#{platform}-#{int}".gsub(%r{[/\\]}, '-') # Strip slashes
   platform_dir = get_vagrant_dir(platform, vagrant_dirs, int + 1) if vagrant_dirs.include?(platform_dir)
   platform_dir
 end


### PR DESCRIPTION
## Summary
Fixes https://github.com/puppetlabs/provision/issues/227

## Additional Context
Add any additional context about the problem here. 
- [x] Root cause -> `i` input parameter was updated to `int` during puppet 8 work, but `i` variable was left unchanged.

## Related Issues (if any)
Mention any related issues or pull requests.

## Checklist
- [ ] 🟢 Spec tests.
- [ ] 🟢 Acceptance tests.
- [x] Manually verified.
