### PR TITLE
(CAT-1264) - Drop Support for EOL Windows 2008 R2, Debian 8 + Ubuntu 16.04

### DIFF
--- a/metadata.json
+++ b/metadata.json
@@ -37,20 +37,15 @@
     },
     {
       "operatingsystem": "Debian",
-      "operatingsystemrelease": [
-        "8"
-      ]
+      "operatingsystemrelease": []
     },
     {
       "operatingsystem": "Ubuntu",
-      "operatingsystemrelease": [
-        "16.04"
-      ]
+      "operatingsystemrelease": []
     },
     {
       "operatingsystem": "windows",
       "operatingsystemrelease": [
-        "2008 R2",
         "2012 R2",
         "10"
       ]


### PR DESCRIPTION
## Summary
Drop support for OS no longer supported by puppet agent.
refer [here](https://www.puppet.com/docs/pe/2023.2/supported_operating_systems.html#supported_operating_systems_and_devices-supported-agent-platforms).

## Additional Context
Add any additional context about the problem here. 
- [ ] Root cause and the steps to reproduce. (If applicable)
- [ ] Thought process behind the implementation.

## Related Issues (if any)
Mention any related issues or pull requests.

## Checklist
- [ ] 🟢 Spec tests.
- [ ] 🟢 Acceptance tests.
- [ ] Manually verified.
