### PR TITLE
(maint) - Update to use module ci

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,15 +7,6 @@ on:
   workflow_dispatch:
 
 jobs:
-  spec:
-    strategy:
-      fail-fast: false
-      matrix:
-        ruby_version:
-          - '2.7'
-          - '3.2'
-    name: "spec (ruby ${{ matrix.ruby_version }})"
-    uses: "puppetlabs/cat-github-actions/.github/workflows/gem_ci.yml@main"
+  Spec:
+    uses: "puppetlabs/cat-github-actions/.github/workflows/module_ci.yml@main"
     secrets: "inherit"
-    with:
-      ruby_version: ${{ matrix.ruby_version }}

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -6,15 +6,6 @@ on:
   workflow_dispatch:
 
 jobs:
-  spec:
-    strategy:
-      fail-fast: false
-      matrix:
-        ruby_version:
-          - '2.7'
-          - '3.2'
-    name: "spec (ruby ${{ matrix.ruby_version }})"
-    uses: "puppetlabs/cat-github-actions/.github/workflows/gem_ci.yml@main"
+  Spec:
+    uses: "puppetlabs/cat-github-actions/.github/workflows/module_ci.yml@main"
     secrets: "inherit"
-    with:
-      ruby_version: ${{ matrix.ruby_version }}


### PR DESCRIPTION
## Summary
this module incorrectly used the gem ci testing.
this Pr updates to use the module CI testing instead.

## Additional Context
Add any additional context about the problem here. 
- [ ] Root cause and the steps to reproduce. (If applicable)
- [ ] Thought process behind the implementation.

## Related Issues (if any)
Mention any related issues or pull requests.

## Checklist
- [ ] 🟢 Spec tests.
- [ ] 🟢 Acceptance tests.
- [ ] Manually verified.
