### PR TITLE
(MAINT) RSpec testing format parameter

### DIFF
--- a/tasks/run_tests.json
+++ b/tasks/run_tests.json
@@ -10,6 +10,11 @@
     "test_path": {
       "description": "Location of the test files. Defaults to './spec/acceptance'",
       "type": "Optional[String[1]]"
+    },
+    "format": {
+      "description": "",
+      "type": "Enum[progress, documentation]",
+      "default": "progress"
     }
   },
   "files": [

--- a/tasks/run_tests.rb
+++ b/tasks/run_tests.rb
@@ -4,8 +4,8 @@
 require 'puppet_litmus'
 require_relative '../lib/task_helper'
 
-def run_tests(sut, test_path)
-  test = "bundle exec rspec #{test_path} --format progress"
+def run_tests(sut, test_path, format)
+  test = "bundle exec rspec #{test_path} --format #{format}"
   options = {
     env: {
       'TARGET_HOST' => sut
@@ -25,8 +25,10 @@ test_path = if params['test_path'].nil?
             else
               params['test_path']
             end
+format = params['format']
+
 begin
-  result = run_tests(sut, test_path)
+  result = run_tests(sut, test_path, format)
   puts result.to_json
   exit 0
 rescue StandardError => e


### PR DESCRIPTION
## Summary

This commit parameterizes the RSpec testing format in the `provision::run_tests` task to allow users to specify either `progress` (**default**) or `documentation`.

## Additional Context
Add any additional context about the problem here. 
- The current implementation of the task only allows for RSpec **progress** output which prints dots (`.`) for passing examples, `F` for failures, `*` for pending. As a user I would like to see more verbose output from the tests I am running. The **documentation** output prints the docstrings passed to `describe` and `it` methods.
- As the task currently hardcodes output to **progress**, I have ensured this is the default parameter value.

## Checklist
- [X] 🟢 Spec tests.
- [X] Manually verified.
