### PR TITLE
(maint) cleanup docker support

### DIFF
--- a/lib/docker_helper.rb
+++ b/lib/docker_helper.rb
@@ -45,3 +45,8 @@ def docker_tear_down(node_name, inventory_location)
   File.open(inventory_full_path, 'w') { |f| f.write inventory_hash.to_yaml }
   { status: 'ok' }
 end
+
+# Workaround for fixing the bash message in stderr when tty is missing
+def docker_fix_missing_tty_error_message(container_id)
+  system("docker exec #{container_id} sed -i 's/^mesg n/tty -s \\&\\& mesg n/g' /root/.profile")
+end

--- a/lib/docker_helper.rb
+++ b/lib/docker_helper.rb
@@ -1,0 +1,28 @@
+# frozen_string_literal: true
+
+def docker_image_os_release_facts(image)
+  os_release_facts = {}
+  begin
+    os_release = run_local_command("docker run --rm #{image} cat /etc/os-release")
+    # The or-release file is a newline-separated list of environment-like
+    # shell-compatible variable assignments.
+    re = '^(.+)=(.+)'
+    os_release.each_line do |line|
+      line = line.strip || line
+      next if line.nil || line.empty?
+
+      _, key, value = line.match(re).to_a
+      # The values seems to be quoted most of the time, however debian only quotes
+      # some of the values :/.  Parse it, as if it was a JSON string.
+      value = JSON.parse(value) unless value[0] != '"'
+      os_release_facts[key] = value
+    end
+  rescue StandardError
+    # fall through to parsing the id and version from the image if it doesn't have `/etc/os-release`
+    id, version_id = image.split(':')
+    id = id.sub(%r{/}, '_')
+    os_release_facts['ID'] = id
+    os_release_facts['VERSION_ID'] = version_id
+  end
+  os_release_facts
+end

--- a/lib/docker_helper.rb
+++ b/lib/docker_helper.rb
@@ -30,3 +30,18 @@ def docker_image_os_release_facts(image)
   end
   os_release_facts
 end
+
+def docker_tear_down(node_name, inventory_location)
+  include PuppetLitmus::InventoryManipulation
+  inventory_full_path = File.join(inventory_location, '/spec/fixtures/litmus_inventory.yaml')
+  raise "Unable to find '#{inventory_full_path}'" unless File.file?(inventory_full_path)
+
+  inventory_hash = inventory_hash_from_inventory_file(inventory_full_path)
+  node_facts = facts_from_node(inventory_hash, node_name)
+  remove_docker = "docker rm -f #{node_facts['container_id']}"
+  run_local_command(remove_docker)
+  remove_node(inventory_hash, node_name)
+  puts "Removed #{node_name}"
+  File.open(inventory_full_path, 'w') { |f| f.write inventory_hash.to_yaml }
+  { status: 'ok' }
+end

--- a/lib/docker_helper.rb
+++ b/lib/docker_helper.rb
@@ -1,5 +1,9 @@
 # frozen_string_literal: true
 
+def docker_exec(container, command)
+  run_local_command("docker exec #{container} #{command}")
+end
+
 def docker_image_os_release_facts(image)
   os_release_facts = {}
   begin

--- a/lib/task_helper.rb
+++ b/lib/task_helper.rb
@@ -69,8 +69,3 @@ def token_from_fogfile(provider = 'abs')
 rescue StandardError
   puts 'Failed to get token from .fog file'
 end
-
-# Workaround for fixing the bash message in stderr when tty is missing
-def fix_missing_tty_error_message(container_id)
-  system("docker exec #{container_id} sed -i 's/^mesg n/tty -s \\&\\& mesg n/g' /root/.profile")
-end

--- a/metadata.json
+++ b/metadata.json
@@ -1,6 +1,6 @@
 {
   "name": "puppetlabs-provision",
-  "version": "2.1.1",
+  "version": "2.1.2",
   "author": "puppetlabs",
   "summary": "Provisions and tears down containers / vms / machines through tasks.",
   "license": "Apache-2.0",

--- a/tasks/docker.json
+++ b/tasks/docker.json
@@ -26,6 +26,7 @@
     }
   },
   "files": [
-    "provision/lib/task_helper.rb"
+    "provision/lib/task_helper.rb",
+    "provision/lib/docker_helper.rb"
   ]
 }

--- a/tasks/docker.rb
+++ b/tasks/docker.rb
@@ -43,13 +43,6 @@ def install_ssh_components(distro, version, container)
     docker_exec(container, 'zypper -n in openssh')
     docker_exec(container, 'ssh-keygen -A')
     docker_exec(container, 'sed -ri "s/^#?UsePAM .*/UsePAM no/" /etc/ssh/sshd_config')
-  when %r{archlinux}
-    docker_exec(container, 'pacman --noconfirm -Sy archlinux-keyring')
-    docker_exec(container, 'pacman --noconfirm -Syu')
-    docker_exec(container, 'pacman -S --noconfirm openssh')
-    docker_exec(container, 'ssh-keygen -A')
-    docker_exec(container, 'sed -ri "s/^#?UsePAM .*/UsePAM no/" /etc/ssh/sshd_config')
-    docker_exec(container, 'systemctl enable sshd')
   else
     raise "distribution #{distro} not yet supported on docker"
   end
@@ -79,7 +72,7 @@ def install_ssh_components(distro, version, container)
     else
       docker_exec(container, 'service sshd restart')
     end
-  when %r{sles}
+  when %r{opensuse}, %r{sles}
     docker_exec(container, '/usr/sbin/sshd')
   else
     raise "distribution #{distro} not yet supported on docker"

--- a/tasks/docker.rb
+++ b/tasks/docker.rb
@@ -143,6 +143,7 @@ def provision(docker_platform, inventory_location, vars)
 
   inventory_node = {
     uri: "#{hostname}:#{front_facing_port}",
+    alias: "#{hostname}:#{front_facing_port}",
     config: {
       transport: 'ssh',
       ssh: {

--- a/tasks/docker.rb
+++ b/tasks/docker.rb
@@ -126,14 +126,15 @@ def random_ssh_forwarding_port(start_port = 52_222, end_port = 52_999)
   random_ssh_forwarding_port(new_start_port, new_end_port)
 end
 
-def provision(image, inventory_location, vars)
+def provision(docker_platform, inventory_location, vars)
   include PuppetLitmus::InventoryManipulation
   inventory_full_path = File.join(inventory_location, '/spec/fixtures/litmus_inventory.yaml')
   inventory_hash = get_inventory_hash(inventory_full_path)
-  os_release_facts = docker_image_os_release_facts(image)
+  os_release_facts = docker_image_os_release_facts(docker_platform)
   distro = os_release_facts['ID']
   version = os_release_facts['VERSION_ID']
 
+  # support for ssh to remote docker
   hostname = (ENV['DOCKER_HOST'].nil? || ENV['DOCKER_HOST'].empty?) ? 'localhost' : URI.parse(ENV.fetch('DOCKER_HOST', nil)).host || ENV.fetch('DOCKER_HOST', nil)
   begin
     # Use the current docker context to determine the docker hostname
@@ -144,44 +145,56 @@ def provision(image, inventory_location, vars)
     # old clients may not support docker context
   end
 
-  group_name = 'ssh_nodes'
   warn '!!! Using private port forwarding!!!'
   front_facing_port = random_ssh_forwarding_port
 
-  node = {
-    'uri' => "#{hostname}:#{front_facing_port}",
-    'config' => {
-      'transport' => 'ssh',
-      'ssh' => { 'user' => 'root', 'password' => 'root', 'port' => front_facing_port, 'host-key-check' => false, 'connect-timeout' => 120 }
+  inventory_node = {
+    uri: "#{hostname}:#{front_facing_port}",
+    config: {
+      transport: 'ssh',
+      ssh: {
+        user: 'root',
+        password: 'root',
+        port: front_facing_port,
+        'host-key-check': false,
+        'connect-timeout': 120
+      }
     },
-    'facts' => {
-      'provisioner' => 'docker',
-      'platform' => image,
-      'os-release' => os_release_facts
+    facts: {
+      provisioner: 'docker',
+      platform: docker_platform,
+      'os-release': os_release_facts
     }
   }
+
   docker_run_opts = ''
   unless vars.nil?
     var_hash = YAML.safe_load(vars)
-    node['vars'] = var_hash
+    inventory_node[:vars] = var_hash
     docker_run_opts = var_hash['docker_run_opts'].flatten.join(' ') unless var_hash['docker_run_opts'].nil?
   end
 
-  docker_run_opts += ' --volume /sys/fs/cgroup:/sys/fs/cgroup:rw' if (image =~ %r{debian|ubuntu}) \
-  && !docker_run_opts.include?('--volume /sys/fs/cgroup:/sys/fs/cgroup')
-  docker_run_opts += ' --cgroupns=host' if (image =~ %r{debian|ubuntu}) \
-  && !docker_run_opts.include?('--cgroupns')
+  if docker_platform.match?(%r{debian|ubuntu})
+    docker_run_opts += ' --volume /sys/fs/cgroup:/sys/fs/cgroup:rw' unless docker_run_opts.include?('--volume /sys/fs/cgroup:/sys/fs/cgroup')
+    docker_run_opts += ' --cgroupns=host' unless docker_run_opts.include?('--cgroupns')
+  end
 
-  creation_command = "docker run -d -it --privileged --tmpfs /tmp:exec -p #{front_facing_port}:22 "
+  creation_command = 'docker run -d -it --privileged --tmpfs /tmp:exec '
+  creation_command += "-p #{front_facing_port}:22 "
   creation_command += "#{docker_run_opts} " unless docker_run_opts.nil?
-  creation_command += image
+  creation_command += docker_platform
+
   container_id = run_local_command(creation_command).strip[0..11]
-  node['name'] = container_id
-  node['facts']['container_id'] = container_id
+
   install_ssh_components(distro, version, container_id)
-  add_node_to_group(inventory_hash, node, group_name)
+
+  inventory_node[:name] = container_id
+  inventory_node[:facts][:container_id] = container_id
+
+  add_node_to_group(inventory_hash, inventory_node, 'ssh_nodes')
   File.open(inventory_full_path, 'w') { |f| f.write inventory_hash.to_yaml }
-  { status: 'ok', node_name: container_id, node: node }
+
+  { status: 'ok', node_name: inventory_node[:name], node: inventory_node }
 end
 
 params = JSON.parse($stdin.read)

--- a/tasks/docker_exp.json
+++ b/tasks/docker_exp.json
@@ -26,6 +26,7 @@
     }
   },
   "files": [
-    "provision/lib/task_helper.rb"
+    "provision/lib/task_helper.rb",
+    "provision/lib/docker_helper.rb"
   ]
 }

--- a/tasks/docker_exp.rb
+++ b/tasks/docker_exp.rb
@@ -5,6 +5,7 @@ require 'json'
 require 'yaml'
 require 'puppet_litmus'
 require_relative '../lib/task_helper'
+require_relative '../lib/docker_helper'
 
 # TODO: detect what shell to use
 @shell_command = 'bash -lc'
@@ -13,6 +14,7 @@ def provision(docker_platform, inventory_location, vars)
   include PuppetLitmus::InventoryManipulation
   inventory_full_path = File.join(inventory_location, '/spec/fixtures/litmus_inventory.yaml')
   inventory_hash = get_inventory_hash(inventory_full_path)
+  os_release_facts = docker_image_os_release_facts(image)
 
   docker_run_opts = ''
   unless vars.nil?
@@ -30,7 +32,7 @@ def provision(docker_platform, inventory_location, vars)
   fix_missing_tty_error_message(container_id) unless platform_is_windows?(docker_platform)
   node = { 'uri' => container_id,
            'config' => { 'transport' => 'docker', 'docker' => { 'shell-command' => @shell_command, 'connect-timeout' => 120 } },
-           'facts' => { 'provisioner' => 'docker_exp', 'container_id' => container_id, 'platform' => docker_platform } }
+           'facts' => { 'provisioner' => 'docker_exp', 'container_id' => container_id, 'platform' => docker_platform, 'os-release' => os_release_facts } }
   unless vars.nil?
     var_hash = YAML.safe_load(vars)
     node['vars'] = var_hash

--- a/tasks/docker_exp.rb
+++ b/tasks/docker_exp.rb
@@ -49,7 +49,7 @@ def provision(docker_platform, inventory_location, vars)
 
   container_id = run_local_command(creation_command).strip[0..11]
 
-  fix_missing_tty_error_message(container_id) unless platform_is_windows?(docker_platform)
+  docker_fix_missing_tty_error_message(container_id) unless platform_is_windows?(docker_platform)
 
   inventory_node[:name] = container_id
   inventory_node[:uri] = container_id

--- a/tasks/docker_exp.rb
+++ b/tasks/docker_exp.rb
@@ -44,21 +44,6 @@ def provision(docker_platform, inventory_location, vars)
   { status: 'ok', node_name: container_id, node: node }
 end
 
-def tear_down(node_name, inventory_location)
-  include PuppetLitmus::InventoryManipulation
-  inventory_full_path = File.join(inventory_location, '/spec/fixtures/litmus_inventory.yaml')
-  raise "Unable to find '#{inventory_full_path}'" unless File.file?(inventory_full_path)
-
-  inventory_hash = inventory_hash_from_inventory_file(inventory_full_path)
-  node_facts = facts_from_node(inventory_hash, node_name)
-  remove_docker = "docker rm -f #{node_facts['container_id']}"
-  run_local_command(remove_docker)
-  remove_node(inventory_hash, node_name)
-  puts "Removed #{node_name}"
-  File.open(inventory_full_path, 'w') { |f| f.write inventory_hash.to_yaml }
-  { status: 'ok' }
-end
-
 params = JSON.parse($stdin.read)
 action = params['action']
 inventory_location = sanitise_inventory_location(params['inventory'])
@@ -81,7 +66,7 @@ end
 
 begin
   result = provision(platform, inventory_location, vars) if action == 'provision'
-  result = tear_down(node_name, inventory_location) if action == 'tear_down'
+  result = docker_tear_down(node_name, inventory_location) if action == 'tear_down'
   puts result.to_json
   exit 0
 rescue StandardError => e


### PR DESCRIPTION
Commits are simply a long overdue housekeeping. Reconcile the two docker tasks to ensure they create containers and manage the bolt inventory in exactly the same way. This is the first in a set to support provisioning unprivileged docker containers.

The docker_exp provision task is **far** more efficient, less complicated, and easier to support than the docker task.
Would like to see it become the default, so I'm adding [smoke testing to Litmusimage](https://github.com/h0tw1r3/litmusimage/actions/runs/7881329056/job/21504779672#step:10:80).