### PR TITLE
Cleanup docker support

### DIFF
--- a/lib/docker_helper.rb
+++ b/lib/docker_helper.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 require 'json'
+require 'puppet_litmus'
 
 def docker_exec(container, command)
   run_local_command("docker exec #{container} #{command}")
@@ -31,4 +32,19 @@ def docker_image_os_release_facts(image)
     os_release_facts['VERSION_ID'] = version_id
   end
   os_release_facts
+end
+
+def docker_tear_down(node_name, inventory_location)
+  extend PuppetLitmus::InventoryManipulation
+  inventory_full_path = File.join(inventory_location, '/spec/fixtures/litmus_inventory.yaml')
+  raise "Unable to find '#{inventory_full_path}'" unless File.file?(inventory_full_path)
+
+  inventory_hash = inventory_hash_from_inventory_file(inventory_full_path)
+  node_facts = facts_from_node(inventory_hash, node_name)
+  remove_docker = "docker rm -f #{node_facts['container_id']}"
+  run_local_command(remove_docker)
+  remove_node(inventory_hash, node_name)
+  puts "Removed #{node_name}"
+  File.open(inventory_full_path, 'w') { |f| f.write inventory_hash.to_yaml }
+  { status: 'ok' }
 end

--- a/lib/docker_helper.rb
+++ b/lib/docker_helper.rb
@@ -1,0 +1,30 @@
+# frozen_string_literal: true
+
+require 'json'
+
+def docker_image_os_release_facts(image)
+  os_release_facts = {}
+  begin
+    os_release = run_local_command("docker run --rm #{image} cat /etc/os-release")
+    # The or-release file is a newline-separated list of environment-like
+    # shell-compatible variable assignments.
+    re = '^(.+)=(.+)'
+    os_release.each_line do |line|
+      line = line.strip || line
+      next if line.nil? || line.empty?
+
+      _, key, value = line.match(re).to_a
+      # The values seems to be quoted most of the time, however debian only quotes
+      # some of the values :/.  Parse it, as if it was a JSON string.
+      value = JSON.parse(value) unless value[0] != '"'
+      os_release_facts[key] = value
+    end
+  rescue StandardError
+    # fall through to parsing the id and version from the image if it doesn't have `/etc/os-release`
+    id, version_id = image.split(':')
+    id = id.sub(%r{/}, '_')
+    os_release_facts['ID'] = id
+    os_release_facts['VERSION_ID'] = version_id
+  end
+  os_release_facts
+end

--- a/lib/docker_helper.rb
+++ b/lib/docker_helper.rb
@@ -48,3 +48,8 @@ def docker_tear_down(node_name, inventory_location)
   File.open(inventory_full_path, 'w') { |f| f.write inventory_hash.to_yaml }
   { status: 'ok' }
 end
+
+# Workaround for fixing the bash message in stderr when tty is missing
+def docker_fix_missing_tty_error_message(container_id)
+  system("docker exec #{container_id} sed -i 's/^mesg n/tty -s \\&\\& mesg n/g' /root/.profile")
+end

--- a/lib/docker_helper.rb
+++ b/lib/docker_helper.rb
@@ -2,6 +2,10 @@
 
 require 'json'
 
+def docker_exec(container, command)
+  run_local_command("docker exec #{container} #{command}")
+end
+
 def docker_image_os_release_facts(image)
   os_release_facts = {}
   begin

--- a/lib/task_helper.rb
+++ b/lib/task_helper.rb
@@ -69,8 +69,3 @@ def token_from_fogfile(provider = 'abs')
 rescue StandardError
   puts 'Failed to get token from .fog file'
 end
-
-# Workaround for fixing the bash message in stderr when tty is missing
-def fix_missing_tty_error_message(container_id)
-  system("docker exec #{container_id} sed -i 's/^mesg n/tty -s \\&\\& mesg n/g' /root/.profile")
-end

--- a/spec/unit/docker_helper_spec.rb
+++ b/spec/unit/docker_helper_spec.rb
@@ -1,0 +1,107 @@
+# frozen_string_literal: true
+
+require 'docker_helper'
+require 'stringio'
+
+describe 'Docker Helper Functions' do
+  let(:container_id) { 'abc12345' }
+  let(:inventory_location) { '.' }
+  let(:full_inventory_location) { "#{inventory_location}/spec/fixtures/litmus_inventory.yaml" }
+  let(:inventory_yaml) do
+    <<-YAML
+    version: 2
+    groups:
+    - name: docker_nodes
+      targets:
+      - name: #{container_id}
+        uri: #{container_id}
+        config:
+          transport: docker
+          docker:
+            shell-command: bash -lc
+            connect-timeout: 120
+        facts:
+          provisioner: docker_exp
+          container_id: #{container_id}
+          platform: litmusimage/debian:12
+          os-release:
+            PRETTY_NAME: Debian GNU/Linux 12 (bookworm)
+            NAME: Debian GNU/Linux
+            VERSION_ID: '12'
+            VERSION: 12 (bookworm)
+            VERSION_CODENAME: bookworm
+            ID: debian
+            HOME_URL: https://www.debian.org/
+            SUPPORT_URL: https://www.debian.org/support
+            BUG_REPORT_URL: https://bugs.debian.org/
+    - name: ssh_nodes
+      targets: []
+    - name: winrm_nodes
+      targets: []
+    - name: lxd_nodes
+      targets: []
+    YAML
+  end
+
+  let(:os_release_facts) do
+    <<-FILE
+    PRETTY_NAME="Debian GNU/Linux 12 (bookworm)"
+    NAME="Debian GNU/Linux"
+    VERSION_ID="12"
+    VERSION="12 (bookworm)"
+    VERSION_CODENAME=bookworm
+    ID=debian
+    HOME_URL="https://www.debian.org/"
+    SUPPORT_URL="https://www.debian.org/support"
+    BUG_REPORT_URL="https://bugs.debian.org/"
+    FILE
+  end
+
+  describe '.docker_exec' do
+    it 'calls run_local_command' do
+      allow(self).to receive(:run_local_command).with("docker exec #{container_id} a command").and_return('some output')
+      expect(docker_exec(container_id, 'a command')).to eq('some output')
+    end
+  end
+
+  describe '.docker_image_os_release_facts' do
+    it 'returns parsed hash of /etc/os-release from container' do
+      allow(self).to receive(:run_local_command)
+        .with('docker run --rm litmusimage/debian:12 cat /etc/os-release')
+        .and_return(os_release_facts)
+      expect(docker_image_os_release_facts('litmusimage/debian:12')).to match(hash_including('PRETTY_NAME' => 'Debian GNU/Linux 12 (bookworm)'))
+    end
+
+    it 'returns minimal facts if parse fails for any reason' do
+      allow(self).to receive(:run_local_command)
+        .with('docker run --rm litmusimage/debian:12 cat /etc/os-release')
+        .and_return(StandardError)
+      expect(docker_image_os_release_facts('litmusimage/debian:12')).to match(hash_including('ID' => 'litmusimage_debian'))
+    end
+  end
+
+  describe '.docker_tear_down' do
+    it 'expect to raise error if inventory file is not found' do
+      allow(File).to receive(:file?).and_return(false)
+      expect { docker_tear_down(container_id, inventory_location) }.to raise_error(RuntimeError, "Unable to find '#{inventory_location}/spec/fixtures/litmus_inventory.yaml'")
+    end
+
+    it 'expect to return status ok' do
+      allow(File).to receive(:file?).with(full_inventory_location).and_return(true)
+      allow(File).to receive(:exist?).with(full_inventory_location).and_return(true)
+      allow(File).to receive(:open).with(full_inventory_location, anything).and_yield(StringIO.new(inventory_yaml.dup))
+      allow(self).to receive(:run_local_command).with("docker rm -f #{container_id}")
+      allow(self).to receive(:remove_node).and_return(nil)
+      expect {
+        expect(docker_tear_down(container_id, inventory_location)).to eql({ status: 'ok' })
+      }.to output("Removed #{container_id}\n").to_stdout
+    end
+  end
+
+  describe '.docker_fix_missing_tty_error_message' do
+    it 'execute command on container to disable mesg' do
+      allow(self).to receive(:system).with("docker exec #{container_id} sed -i 's/^mesg n/tty -s \\&\\& mesg n/g' /root/.profile")
+      expect(docker_fix_missing_tty_error_message(container_id)).to be_nil
+    end
+  end
+end

--- a/tasks/docker.json
+++ b/tasks/docker.json
@@ -26,6 +26,7 @@
     }
   },
   "files": [
-    "provision/lib/task_helper.rb"
+    "provision/lib/task_helper.rb",
+    "provision/lib/docker_helper.rb"
   ]
 }

--- a/tasks/docker.rb
+++ b/tasks/docker.rb
@@ -43,13 +43,6 @@ def install_ssh_components(distro, version, container)
     docker_exec(container, 'zypper -n in openssh')
     docker_exec(container, 'ssh-keygen -A')
     docker_exec(container, 'sed -ri "s/^#?UsePAM .*/UsePAM no/" /etc/ssh/sshd_config')
-  when %r{archlinux}
-    docker_exec(container, 'pacman --noconfirm -Sy archlinux-keyring')
-    docker_exec(container, 'pacman --noconfirm -Syu')
-    docker_exec(container, 'pacman -S --noconfirm openssh')
-    docker_exec(container, 'ssh-keygen -A')
-    docker_exec(container, 'sed -ri "s/^#?UsePAM .*/UsePAM no/" /etc/ssh/sshd_config')
-    docker_exec(container, 'systemctl enable sshd')
   else
     raise "distribution #{distro} not yet supported on docker"
   end
@@ -79,7 +72,7 @@ def install_ssh_components(distro, version, container)
     else
       docker_exec(container, 'service sshd restart')
     end
-  when %r{sles}
+  when %r{opensuse}, %r{sles}
     docker_exec(container, '/usr/sbin/sshd')
   else
     raise "distribution #{distro} not yet supported on docker"

--- a/tasks/docker.rb
+++ b/tasks/docker.rb
@@ -12,76 +12,75 @@ def install_ssh_components(distro, version, container)
   case distro
   when %r{debian}, %r{ubuntu}, %r{cumulus}
     warn '!!! Disabling ESM security updates for ubuntu - no access without privilege !!!'
-    run_local_command("docker exec #{container} rm -f /etc/apt/sources.list.d/ubuntu-esm-infra-trusty.list")
-    run_local_command("docker exec #{container} apt-get update")
-    run_local_command("docker exec #{container} apt-get install -y openssh-server openssh-client")
+    docker_exec(container, 'rm -f /etc/apt/sources.list.d/ubuntu-esm-infra-trusty.list')
+    docker_exec(container, 'apt-get update')
+    docker_exec(container, 'apt-get install -y openssh-server openssh-client')
   when %r{fedora}
-    run_local_command("docker exec #{container} dnf clean all")
-    run_local_command("docker exec #{container} dnf install -y sudo openssh-server openssh-clients")
-    run_local_command("docker exec #{container} ssh-keygen -A")
+    docker_exec(container, 'dnf clean all')
+    docker_exec(container, 'dnf install -y sudo openssh-server openssh-clients')
+    docker_exec(container, 'ssh-keygen -A')
   when %r{centos}, %r{^el-}, %r{eos}, %r{oracle}, %r{ol}, %r{rhel|redhat}, %r{scientific}, %r{amzn}, %r{rocky}, %r{almalinux}
     if version == '6'
       # sometimes the redhat 6 variant containers like to eat their rpmdb, leading to
       # issues with "rpmdb: unable to join the environment" errors
       # This "fix" is from https://www.srv24x7.com/criticalyum-main-error-rpmdb-open-failed/
-      run_local_command("docker exec #{container} bash -exc \"rm -f /var/lib/rpm/__db*; " \
+      docker_exec(container, 'bash -exc "rm -f /var/lib/rpm/__db*; ' \
                         'db_verify /var/lib/rpm/Packages; ' \
                         'rpm --rebuilddb; ' \
-                        'yum clean all; ' \
-                        'yum install -y sudo openssh-server openssh-clients"')
+                        'yum clean all"')
     else
       # If systemd is running for init, ensure systemd has finished starting up before proceeding:
       check_init_cmd = 'if [[ "$(readlink /proc/1/exe)" == "/usr/lib/systemd/systemd" ]]; then ' \
                        'count=0 ; while ! [[ "$(systemctl is-system-running)" =~ ^running|degraded$ && $count > 20 ]]; ' \
                        'do sleep 0.1 ; count=$((count+1)) ; done ; fi'
-      run_local_command("docker exec #{container} bash -c '#{check_init_cmd}'")
-      run_local_command("docker exec #{container} yum install -y sudo openssh-server openssh-clients")
+      docker_exec(container, "bash -c '#{check_init_cmd}'")
     end
-    ssh_folder = run_local_command("docker exec #{container} ls /etc/ssh/")
-    run_local_command("docker exec #{container} ssh-keygen -t rsa -f /etc/ssh/ssh_host_rsa_key -N \"\"") unless ssh_folder.include?('ssh_host_rsa_key')
-    run_local_command("docker exec #{container} ssh-keygen -t dsa -f /etc/ssh/ssh_host_dsa_key -N \"\"") unless ssh_folder.include?('ssh_host_dsa_key')
+    docker_exec(container, 'yum install -y sudo openssh-server openssh-clients')
+    ssh_folder = docker_exec(container, 'ls /etc/ssh/')
+    docker_exec(container, 'ssh-keygen -t rsa -f /etc/ssh/ssh_host_rsa_key -N ""') unless ssh_folder.include?('ssh_host_rsa_key')
+    docker_exec(container, 'ssh-keygen -t dsa -f /etc/ssh/ssh_host_dsa_key -N ""') unless ssh_folder.include?('ssh_host_dsa_key')
   when %r{opensuse}, %r{sles}
-    run_local_command("docker exec #{container} zypper -n in openssh")
-    run_local_command("docker exec #{container} ssh-keygen -A")
-    run_local_command("docker exec #{container} sed -ri \"s/^#?UsePAM .*/UsePAM no/\" /etc/ssh/sshd_config")
+    docker_exec(container, 'zypper -n in openssh')
+    docker_exec(container, 'ssh-keygen -A')
+    docker_exec(container, 'sed -ri "s/^#?UsePAM .*/UsePAM no/" /etc/ssh/sshd_config')
   when %r{archlinux}
-    run_local_command("docker exec #{container} pacman --noconfirm -Sy archlinux-keyring")
-    run_local_command("docker exec #{container} pacman --noconfirm -Syu")
-    run_local_command("docker exec #{container} pacman -S --noconfirm openssh")
-    run_local_command("docker exec #{container} ssh-keygen -A")
-    run_local_command("docker exec #{container} sed -ri \"s/^#?UsePAM .*/UsePAM no/\" /etc/ssh/sshd_config")
-    run_local_command("docker exec #{container} systemctl enable sshd")
+    docker_exec(container, 'pacman --noconfirm -Sy archlinux-keyring')
+    docker_exec(container, 'pacman --noconfirm -Syu')
+    docker_exec(container, 'pacman -S --noconfirm openssh')
+    docker_exec(container, 'ssh-keygen -A')
+    docker_exec(container, 'sed -ri "s/^#?UsePAM .*/UsePAM no/" /etc/ssh/sshd_config')
+    docker_exec(container, 'systemctl enable sshd')
   else
     raise "distribution #{distro} not yet supported on docker"
   end
 
   # Make sshd directory, set root password
-  run_local_command("docker exec #{container} mkdir -p /var/run/sshd")
-  run_local_command("docker exec #{container} bash -c \"echo root:root | /usr/sbin/chpasswd\"")
+  docker_exec(container, 'mkdir -p /var/run/sshd')
+  docker_exec(container, 'bash -c "echo root:root | /usr/sbin/chpasswd"')
 end
 
 def fix_ssh(distro, version, container)
-  run_local_command("docker exec #{container} sed -ri \"s/^#?PermitRootLogin .*/PermitRootLogin yes/\" /etc/ssh/sshd_config")
-  run_local_command("docker exec #{container} sed -ri \"s/^#?PasswordAuthentication .*/PasswordAuthentication yes/\" /etc/ssh/sshd_config")
-  run_local_command("docker exec #{container} sed -ri \"s/^#?UseDNS .*/UseDNS no/\" /etc/ssh/sshd_config")
-  run_local_command("docker exec #{container} sed -e \"/HostKey.*ssh_host_e.*_key/ s/^#*/#/\" -ri /etc/ssh/sshd_config")
+  docker_exec(container, 'sed -ri "s/^#?PermitRootLogin .*/PermitRootLogin yes/" /etc/ssh/sshd_config')
+  docker_exec(container, 'sed -ri "s/^#?PasswordAuthentication .*/PasswordAuthentication yes/" /etc/ssh/sshd_config')
+  docker_exec(container, 'sed -ri "s/^#?UseDNS .*/UseDNS no/" /etc/ssh/sshd_config')
+  docker_exec(container, 'sed -e "/HostKey.*ssh_host_e.*_key/ s/^#*/#/" -ri /etc/ssh/sshd_config')
   case distro
   when %r{debian}, %r{ubuntu}
-    run_local_command("docker exec #{container} service ssh restart")
+    docker_exec(container, 'service ssh restart')
   when %r{centos}, %r{^el-}, %r{eos}, %r{fedora}, %r{ol}, %r{rhel|redhat}, %r{scientific}, %r{amzn}, %r{rocky}, %r{almalinux}
     # Current RedHat/CentOs 7 packs an old version of pam, which are missing a
     # crucial patch when running unprivileged containers.  See:
     # https://bugzilla.redhat.com/show_bug.cgi?id=1728777
-    run_local_command("docker exec #{container} sed 's@session\s*required\s*pam_loginuid.so@session optional pam_loginuid.so@g' -i /etc/pam.d/sshd") \
+    docker_exec(container, 'sed "s@session\s*required\s*pam_loginuid.so@session optional pam_loginuid.so@g" -i /etc/pam.d/sshd') \
       if distro =~ %r{rhel|redhat|centos} && version =~ %r{^7}
 
     if %r{^(7|8|9|2)}.match?(version)
-      run_local_command("docker exec #{container} /usr/sbin/sshd")
+      docker_exec(container, '/usr/sbin/sshd')
     else
-      run_local_command("docker exec #{container} service sshd restart")
+      docker_exec(container, 'service sshd restart')
     end
   when %r{sles}
-    run_local_command("docker exec #{container} /usr/sbin/sshd")
+    docker_exec(container, '/usr/sbin/sshd')
   else
     raise "distribution #{distro} not yet supported on docker"
   end

--- a/tasks/docker_exp.json
+++ b/tasks/docker_exp.json
@@ -26,6 +26,7 @@
     }
   },
   "files": [
-    "provision/lib/task_helper.rb"
+    "provision/lib/task_helper.rb",
+    "provision/lib/docker_helper.rb"
   ]
 }

--- a/tasks/docker_exp.rb
+++ b/tasks/docker_exp.rb
@@ -16,32 +16,49 @@ def provision(docker_platform, inventory_location, vars)
   inventory_hash = get_inventory_hash(inventory_full_path)
   os_release_facts = docker_image_os_release_facts(docker_platform)
 
+  inventory_node = {
+    'config' => {
+      'transport' => 'docker',
+      'docker' => {
+        'shell-command' => @shell_command,
+        'connect-timeout' => 120
+      }
+    },
+    'facts' => {
+      'provisioner' => 'docker_exp',
+      'platform' => docker_platform,
+      'os-release' => os_release_facts,
+    }
+  }
+
   docker_run_opts = ''
   unless vars.nil?
     var_hash = YAML.safe_load(vars)
+    inventory_node['vars'] = var_hash
     docker_run_opts = var_hash['docker_run_opts'].flatten.join(' ') unless var_hash['docker_run_opts'].nil?
   end
 
-  docker_run_opts += ' --volume /sys/fs/cgroup:/sys/fs/cgroup:rw' if (docker_platform =~ %r{debian|ubuntu}) \
-  && !docker_run_opts.include?('--volume /sys/fs/cgroup:/sys/fs/cgroup')
-  docker_run_opts += ' --cgroupns=host' if (docker_platform =~ %r{debian|ubuntu}) \
-  && !docker_run_opts.include?('--cgroupns')
-
-  creation_command = "docker run -d -it --privileged #{docker_run_opts} #{docker_platform}"
-  container_id = run_local_command(creation_command).strip[0..11]
-  fix_missing_tty_error_message(container_id) unless platform_is_windows?(docker_platform)
-  node = { 'uri' => container_id,
-           'config' => { 'transport' => 'docker', 'docker' => { 'shell-command' => @shell_command, 'connect-timeout' => 120 } },
-           'facts' => { 'provisioner' => 'docker_exp', 'container_id' => container_id, 'platform' => docker_platform, 'os-release' => os_release_facts } }
-  unless vars.nil?
-    var_hash = YAML.safe_load(vars)
-    node['vars'] = var_hash
+  if docker_platform.match?(%r{debian|ubuntu})
+    docker_run_opts += ' --volume /sys/fs/cgroup:/sys/fs/cgroup:rw' unless docker_run_opts.include?('--volume /sys/fs/cgroup:/sys/fs/cgroup')
+    docker_run_opts += ' --cgroupns=host' unless docker_run_opts.include?('--cgroupns')
   end
 
-  group_name = 'docker_nodes'
-  add_node_to_group(inventory_hash, node, group_name)
+  creation_command = 'docker run -d -it --privileged --tmpfs /tmp:exec '
+  creation_command += "#{docker_run_opts} " unless docker_run_opts.nil?
+  creation_command += docker_platform
+
+  container_id = run_local_command(creation_command).strip[0..11]
+
+  fix_missing_tty_error_message(container_id) unless platform_is_windows?(docker_platform)
+
+  inventory_node['name'] = container_id
+  inventory_node['uri'] = container_id
+  inventory_node['facts']['container_id'] = container_id
+
+  add_node_to_group(inventory_hash, inventory_node, 'docker_nodes')
   File.open(inventory_full_path, 'w') { |f| f.write inventory_hash.to_yaml }
-  { status: 'ok', node_name: container_id, node: node }
+
+  { status: 'ok', node_name: inventory_node['name'], node: inventory_node }
 end
 
 params = JSON.parse($stdin.read)

--- a/tasks/docker_exp.rb
+++ b/tasks/docker_exp.rb
@@ -49,7 +49,7 @@ def provision(docker_platform, inventory_location, vars)
 
   container_id = run_local_command(creation_command).strip[0..11]
 
-  fix_missing_tty_error_message(container_id) unless platform_is_windows?(docker_platform)
+  docker_fix_missing_tty_error_message(container_id) unless platform_is_windows?(docker_platform)
 
   inventory_node['name'] = container_id
   inventory_node['uri'] = container_id

--- a/tasks/docker_exp.rb
+++ b/tasks/docker_exp.rb
@@ -44,21 +44,6 @@ def provision(docker_platform, inventory_location, vars)
   { status: 'ok', node_name: container_id, node: node }
 end
 
-def tear_down(node_name, inventory_location)
-  include PuppetLitmus::InventoryManipulation
-  inventory_full_path = File.join(inventory_location, '/spec/fixtures/litmus_inventory.yaml')
-  raise "Unable to find '#{inventory_full_path}'" unless File.file?(inventory_full_path)
-
-  inventory_hash = inventory_hash_from_inventory_file(inventory_full_path)
-  node_facts = facts_from_node(inventory_hash, node_name)
-  remove_docker = "docker rm -f #{node_facts['container_id']}"
-  run_local_command(remove_docker)
-  remove_node(inventory_hash, node_name)
-  puts "Removed #{node_name}"
-  File.open(inventory_full_path, 'w') { |f| f.write inventory_hash.to_yaml }
-  { status: 'ok' }
-end
-
 params = JSON.parse($stdin.read)
 action = params['action']
 inventory_location = sanitise_inventory_location(params['inventory'])
@@ -81,7 +66,7 @@ end
 
 begin
   result = provision(platform, inventory_location, vars) if action == 'provision'
-  result = tear_down(node_name, inventory_location) if action == 'tear_down'
+  result = docker_tear_down(node_name, inventory_location) if action == 'tear_down'
   puts result.to_json
   exit 0
 rescue StandardError => e


### PR DESCRIPTION
Commits are simply housekeeping. Reconcile the two docker tasks to ensure they create containers and manage the bolt inventory in exactly the same way. After this I'm hoping we can move to supporting unprivileged docker containers.

These changes can be tested running the [manual workflow on Litmusimage](https://github.com/puppetlabs/litmusimage/actions/workflows/manual.yml) using `{ "git": "https://github.com/h0tw1r3/provision.git", "ref": "docker-dodo" }` for the _provision module_ option after https://github.com/puppetlabs/litmusimage/pull/75 is merged.