### PR TITLE
(CAT-372) - add var support to vagrant provisioner

### DIFF
--- a/README.md
+++ b/README.md
@@ -209,6 +209,12 @@ Successful on 1 node: localhost
 Ran on 1 node in 51.98 seconds
 ```
 
+For multi-node provisioning, you can assign arbitrary tags to the nodes you deploy, by passing an optional YAML-string 'vars' to the bolt task. In the example below we are assigning the role of `k8s-controller` to the provisioned node.
+
+```ruby
+$ bundle exec bolt --modulepath /Users/tp/workspace/git/ task run provision::vagrant --targets localhost  action=provision platform=ubuntu/xenial64 inventory=/Users/tp/workspace/git/provision vars='role: k8s-controller'
+```
+
 sudo secure_path fix
 
 As some Vagrant boxes do not allow ssh root logins, the **vagrant** user is used to login and *sudo* is used to execute privileged commands as root user.
@@ -284,13 +290,13 @@ In the provision step you can invoke bundle exec rake 'litmus:provision_list[tes
 Manual invocation of the provision service task from a workflow can be done using:
 
 ```ruby
-bundle exec bolt --modulepath /Users/tp/workspace/git/ task run provision::provision_service --targets localhost  action=provision platform=centos-7-v20200813 inventory=/Users/tp/workspace/git/provision
+bundle exec bolt --modulepath /Users/tp/workspace/git/ task run provision::provision_service --targets localhost  action=provision platform=centos-7-v20200813 inventory=/Users/tp/workspace/git/provision vars='role: puppetserver'
 ```
 
 Or using Litmus:
 
 ```ruby
-bundle exec rake 'litmus:provision[provision_service, centos-7-v20200813]'
+bundle exec rake 'litmus:provision[provision_service, centos-7-v20200813, role: puppetserver]'
 ```
 
 #### Synced Folders

--- a/spec/tasks/vagrant_spec.rb
+++ b/spec/tasks/vagrant_spec.rb
@@ -1,0 +1,34 @@
+require 'json'
+require 'rspec'
+require 'spec_helper'
+require 'net/ssh'
+
+describe 'vagrant' do
+  let(:provider) { 'virtualbox' }
+  let(:platform) { 'generic/debian10' }
+
+  before(:each) do
+    # Stub $stdin.read to return a predefined JSON string
+    allow($stdin).to receive(:read).and_return({
+      platform: platform,
+      action: 'provision',
+      vars: 'role: worker1',
+      inventory: Dir.pwd.to_s,
+      enable_synced_folder: 'true',
+      provider: provider,
+      hyperv_vswitch: 'hyperv_vswitch',
+      hyperv_smb_username: 'hyperv_smb_username'
+    }.to_json)
+    allow(Open3).to receive(:capture3).with(%r{vagrant up --provider #{provider}}, any_args).and_return(['', '', 0]).once
+    allow(File).to receive(:read).with(%r{#{Dir.pwd}/.vagrant}).and_return('some_unique_id')
+    allow(Open3).to receive(:capture3).with(%r{vagrant ssh-config}, any_args).and_return(['', '', 0]).once
+    allow(Net::SSH).to receive(:start).and_return(true)
+    require_relative '../../tasks/vagrant'
+  end
+
+  it 'provisions a new vagrant box when action is provision' do
+    expect { vagrant }.to output(%r{"status":"ok"}).to_stdout
+    expect { vagrant }.to output(%r{"platform":"generic/debian10"}).to_stdout
+    expect { vagrant }.to output(%r{"role":"worker1"}).to_stdout
+  end
+end

--- a/tasks/vagrant.json
+++ b/tasks/vagrant.json
@@ -58,6 +58,10 @@
     "password": {
       "description": "Password to use for Vagrant boxes without the default Vagrant insecure key",
       "type": "Optional[String[1]]"
+    },
+    "vars": {
+      "description": "YAML string of key/value pairs to add to the inventory vars section",
+      "type": "Optional[String[1]]"
     }
   },
   "files": [

--- a/tasks/vagrant.rb
+++ b/tasks/vagrant.rb
@@ -244,7 +244,10 @@ unless node_name.nil? ^ platform.nil?
 end
 
 begin
-  result = provision(platform, inventory_location, enable_synced_folder, provider, cpus, memory, hyperv_vswitch, hyperv_smb_username, hyperv_smb_password, box_url, password, vars) if action == 'provision'
+  if action == 'provision'
+    result = provision(platform, inventory_location, enable_synced_folder, provider, cpus, memory, hyperv_vswitch, hyperv_smb_username, hyperv_smb_password, box_url, password,
+vars)
+  end
   result = tear_down(node_name, inventory_location) if action == 'tear_down'
   puts result.to_json
   exit 0


### PR DESCRIPTION
## Summary
To use multi-node provisioning locally with vagrant we need to be able to
assign arbitrary tags to the nodes we deploy.
Other provisioners do this with a parameter called vars.

This PR introduces support for this, and essentially copies what is
already present in the other bolt tasks in this module.

## Additional Context
Litmus
```
bundle exec rake 'litmus:provision[vagrant, generic/debian10, role: worker1]'
```
Bolt
```
bundle exec bolt task run provision::vagrant --targets localhost  action=provision platform=generic/debian10 vars='role: worker1'
```

Will return an inventory file like
```

  - uri: 127.0.0.1:2200
    config:
      transport: ssh
      ssh:
        user: vagrant
        host: 127.0.0.1
        host-key-check: false
        port: 2200
        run-as: root
        connect-timeout: 120
        private-key: "path/vagrant.key.ed25519"
    facts:
      provisioner: vagrant
      platform: generic/debian10
      id: 57169c9e3f884f0dbe94dc26cdd8b7f0
      vagrant_env: "path/.vagrant/generic-debian10-6"
    vars:
      role: worker1
```
## Related Issues (if any)
Mention any related issues or pull requests.

## Checklist
- [x] 🟢 Spec tests.
- [ ] 🟢 Acceptance tests.
- [x] Manually verified.
