### PR TITLE
fix tear_down from puppet_litmus

### DIFF
--- a/tasks/docker.rb
+++ b/tasks/docker.rb
@@ -207,7 +207,7 @@ end
 begin
   result = provision(platform, inventory, vars) if action == 'provision'
   if action == 'tear_down'
-    node = inventory.lookup(name: node_name, group: 'ssh_nodes')
+    node = inventory.lookup(node_name, group: 'ssh_nodes')
     result = docker_tear_down(node['facts']['container_id'])
     inventory.remove(node).save
   end

--- a/tasks/docker_exp.rb
+++ b/tasks/docker_exp.rb
@@ -79,7 +79,7 @@ end
 begin
   result = provision(platform, inventory, vars) if action == 'provision'
   if action == 'tear_down'
-    node = inventory.lookup(name: node_name, group: 'docker_nodes')
+    node = inventory.lookup(node_name, group: 'docker_nodes')
     result = docker_tear_down(node['facts']['container_id'])
     inventory.remove(node).save
   end

--- a/tasks/provision_service.rb
+++ b/tasks/provision_service.rb
@@ -138,7 +138,7 @@ class ProvisionService
     # remove all provisioned resources
     uri = URI.parse(ENV['SERVICE_URL'] || default_uri)
 
-    node = inventory.lookup(name: node_name)
+    node = inventory.lookup(node_name)
     facts = node['facts']
     job_id = facts['uuid']
     response = invoke_cloud_request(job_id, uri, '', 'delete', retry_attempts)

--- a/tasks/vagrant.rb
+++ b/tasks/vagrant.rb
@@ -197,7 +197,7 @@ end
 
 def tear_down(node_name, inventory)
   command = 'vagrant destroy -f'
-  node = inventory.lookup(name: node_name, group: 'ssh_nodes')
+  node = inventory.lookup(node_name, group: 'ssh_nodes')
   vagrant_env = node['facts']['vagrant_env']
   run_local_command(command, vagrant_env)
   FileUtils.rm_r(vagrant_env)


### PR DESCRIPTION

## Summary
puppet_litmus gem is passing the target uri as the node_name param, which causes an InventoryHelper.lookup exception.

## Additional Context
- Easily reproducible by following the standard litmus testing workflow with the docker, docker_exp, or vagrant backends. Provisioning and testing works fine, but litmus:tear_down throws an exception.
- By using the unnamed param to lookup instead of `name`, lookup will automatically search for a matching target uri, or name value.

## Checklist
- [x] 🟢 Spec tests.
- [x] Manually verified.
