### PR TITLE
(CAT-1958) - Fix 404 on teardown of abs node

### DIFF
--- a/tasks/abs.rb
+++ b/tasks/abs.rb
@@ -125,7 +125,7 @@ class ABSProvision
 
     uri = URI.parse("https://#{abs_host}/api/v2/return")
     headers = { 'X-AUTH-TOKEN' => token_from_fogfile('abs'), 'Content-Type' => 'application/json' }
-    payload = { 'job_id' => node['job_id'],
+    payload = { 'job_id' => node['facts']['job_id'],
                 'hosts' => [{ 'hostname' => node['uri'], 'type' => node['facts']['platform'], 'engine' => 'vmpooler' }] }
     http = Net::HTTP.new(uri.host, uri.port)
     http.use_ssl = true


### PR DESCRIPTION
## Summary
This alters the request body payload object to correctly reference the node job id which is required for tear_down of an abs node.

## Additional Context
Before: 
```
bundle exec rake 'litmus:tear_down'                                                                                  
HEAD is now at c511041 Merge pull request #647 from puppetlabs/release-prep
rake aborted!
tear_down of our_abs_node.net failed.
Results:
  localhost: {"_error"=>{"kind"=>"provision/abs_failure", "msg"=>"Error: #<Net::HTTPNotFound:0x000000010c2d98a0>: Not Found", "details"=>{}}}}
/Users/jordan.breen/Desktop/repos/modules/puppetlabs-motd/.bundle/gems/ruby/3.2.0/gems/puppet_litmus-1.4.0/lib/puppet_litmus/rake_helper.rb:335:in `raise_bolt_errors'
/Users/jordan.breen/Desktop/repos/modules/puppetlabs-motd/.bundle/gems/ruby/3.2.0/gems/puppet_litmus-1.4.0/lib/puppet_litmus/rake_helper.rb:129:in `tear_down'
/Users/jordan.breen/Desktop/repos/modules/puppetlabs-motd/.bundle/gems/ruby/3.2.0/gems/puppet_litmus-1.4.0/lib/puppet_litmus/rake_helper.rb:104:in `block in tear_down_nodes'
/Users/jordan.breen/Desktop/repos/modules/puppetlabs-motd/.bundle/gems/ruby/3.2.0/gems/puppet_litmus-1.4.0/lib/puppet_litmus/rake_helper.rb:100:in `each'
/Users/jordan.breen/Desktop/repos/modules/puppetlabs-motd/.bundle/gems/ruby/3.2.0/gems/puppet_litmus-1.4.0/lib/puppet_litmus/rake_helper.rb:100:in `tear_down_nodes'
/Users/jordan.breen/Desktop/repos/modules/puppetlabs-motd/.bundle/gems/ruby/3.2.0/gems/puppet_litmus-1.4.0/lib/puppet_litmus/rake_tasks.rb:323:in `block (2 levels) in <top (required)>'
/Users/jordan.breen/Desktop/repos/modules/puppetlabs-motd/.bundle/gems/ruby/3.2.0/gems/rake-13.2.1/exe/rake:27:in `<top (required)>'
/Users/jordan.breen/.rbenv/versions/3.2.0/bin/bundle:25:in `load'
/Users/jordan.breen/.rbenv/versions/3.2.0/bin/bundle:25:in `<main>'
Tasks: TOP => litmus:tear_down
(See full trace by running task with --trace)
```
After:
```
bundle exec rake 'litmus:tear_down'                                                                              
HEAD is now at c511041 Merge pull request #647 from puppetlabs/release-prep
our_abs_node.net: success
```
## Related Issues (if any)
Mention any related issues or pull requests.

## Checklist
- [ ] 🟢 Spec tests.
- [ ] 🟢 Acceptance tests.
- [x] Manually verified.
