### PR TITLE
(MAINT) Support for Puppet Server on Ubuntu 22.04

### DIFF
--- a/tasks/install_puppetserver.sh
+++ b/tasks/install_puppetserver.sh
@@ -94,6 +94,8 @@ fetch_codename() {
     "18.04") codename="bionic";;
     "2004") codename="focal";;
     "20.04") codename="focal";;
+    "2204") codename="jammy";;
+    "22.04") codename="jammy";;
     *) codename="unsupported"
   esac
   echo $codename


### PR DESCRIPTION
## Summary

Upon adding Ubuntu 22.04 to our test matrix I discovered that the `install_puppetserver` task does not support the aforementioned OS.

As such, this commit includes changes to ensure Ubuntu 22.04 is recognized and the package is pulled and installed.

## Additional Context
Add any additional context about the problem here. 
- Current code is missing the codename for Ubuntu 22.04 and returns an error stating that there are no build available for the OS.

## Checklist
- [ ] 🟢 Spec tests.
- [ ] 🟢 Acceptance tests.
- [ ] Manually verified.
