### PR TITLE
(MAINT) Install Puppet Server Task

### DIFF
--- a/tasks/install_puppetserver.json
+++ b/tasks/install_puppetserver.json
@@ -4,11 +4,11 @@
   "description": "install puppetserver community edition",
   "parameters": {
     "collection": {
-      "description": "The name of the node",
+      "description": "The Puppet Server version",
       "type": "Optional[String[1]]"
     },
     "platform": {
-      "description": "The name of the node",
+      "description": "The operating system and version",
       "type": "Optional[String[1]]"
     },
     "retry": {

--- a/tasks/install_puppetserver.sh
+++ b/tasks/install_puppetserver.sh
@@ -150,7 +150,7 @@ if [[ "$osfamily" == "unsupported" ]]; then
 fi
 
 if [[ "$osfamily" == "debian" ]]; then
-  codename=$(fetch_codename "$collection $major_version")
+  codename=$(fetch_codename "$collection" "$major_version")
   if [[ "$codename" == "unsupported" ]]; then
     echo "No builds for $platform"
     exit 1


### PR DESCRIPTION
## Summary

This commit corrects a syntax issue causing the `provision::install_puppetserver` task to fail on the Ubuntu platform.

## Additional Context

The arguments for the `fetch_codename()` function are currently grouped to be passed in as a single argument instead of **`$collection`** and **`$platform`** separately. As a result the task errors out and states there are no builds for Ubuntu.

## Related Issues
Looks like the issue was introduced in this [commit](https://github.com/puppetlabs/provision/commit/0b87fad0ab0a84a4f02a0f6ec0688cf4811c51ef).


## Checklist
- [ ] 🟢 Spec tests.
- [ ] 🟢 Acceptance tests.
- [X] Manually verified.
