### PR TITLE
(PE-39952) Add PE os version

### DIFF
--- a/tasks/install_pe.json
+++ b/tasks/install_pe.json
@@ -6,6 +6,10 @@
       "version": {
       "description": "The release of PE you want to install e.g. 2018.1 (Default: 2019.2)",
       "type": "Optional[String[1]]"
+    },
+      "os": {
+      "description": "The os of PE you are installing e.g. ubuntu-22.04-amd64  (Default: el-7-x86_64)",
+      "type": "Optional[String[1]]"
     }
   },
   "private": true

--- a/tasks/install_pe.sh
+++ b/tasks/install_pe.sh
@@ -7,8 +7,15 @@ else
   PE_RELEASE=$PT_version
 fi
 
+if [ -z ${PT_os+x} ]; then
+  PE_OS=el-7-x86_64
+
+else
+  PE_OS=$PT_os
+fi
+
 PE_LATEST=$(curl https://artifactory.delivery.puppetlabs.net/artifactory/generic_enterprise__local/"${PE_RELEASE}"/ci-ready/LATEST)
-PE_FILE_NAME=puppet-enterprise-${PE_LATEST}-el-7-x86_64
+PE_FILE_NAME=puppet-enterprise-${PE_LATEST}-${PE_OS}
 TAR_FILE=${PE_FILE_NAME}.tar
 DOWNLOAD_URL=https://artifactory.delivery.puppetlabs.net/artifactory/generic_enterprise__local/${PE_RELEASE}/ci-ready/${TAR_FILE}
 


### PR DESCRIPTION
## Summary
Add parameter to specify os bundle that will be downloaded from artifactory.
Currently hardcoded to `el-7-x86_64` and have kept this as default

## Additional Context
We could dynamically determine os distro/version but this is just a quick fix for now.

## Related Issues (if any)
N/A

## Checklist
- [x] 🟢 Spec tests.
- [x] 🟢 Acceptance tests.
- [x] Manually verified. (tested on alma8 by passing el-8-x86_64)
