### PR TITLE
(CAT-2193): Added codename for Debian 11 & 12

### DIFF
--- a/tasks/install_puppetserver.sh
+++ b/tasks/install_puppetserver.sh
@@ -77,6 +77,8 @@ fetch_codename() {
       ;;
     "9") codename="stretch";;
     "10") codename="buster";;
+    "11") codename="bullseye";;
+    "12") codename="bookworm";;
     "1404")
       if [[ "$1" == "puppet6" ]]; then
         codename="trusty"


### PR DESCRIPTION
## Summary
Added Codename for following

1. debian-11: bullseye
2. debian-12: bookworm

It is required by the `puppetlabs-kubernetes` modules tests for debian

## Checklist
- [ ] 🟢 Spec tests.
- [ ] 🟢 Acceptance tests.
- [ ] Manually verified.
