### PR TITLE
feat(puppetcore): Add puppetcore gem source switch capability

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,4 +12,5 @@ jobs:
     with:
       # This line enables shellcheck to be run on this repository
       run_shellcheck: true
+      ruby_version: '3.1'
     secrets: "inherit"

--- a/Gemfile
+++ b/Gemfile
@@ -52,13 +52,20 @@ facter_version = ENV['FACTER_GEM_VERSION']
 hiera_version = ENV['HIERA_GEM_VERSION']
 
 gems = {}
+puppet_version = ENV.fetch('PUPPET_GEM_VERSION', nil)
+facter_version = ENV.fetch('FACTER_GEM_VERSION', nil)
+hiera_version = ENV.fetch('HIERA_GEM_VERSION', nil)
 
-gems['puppet'] = location_for(puppet_version)
+# If PUPPET_FORGE_TOKEN is set then use authenticated source for both puppet and facter, since facter is a transitive dependency of puppet
+# Otherwise, do as before and use location_for to fetch gems from the default source
+if !ENV['PUPPET_FORGE_TOKEN'].to_s.empty?
+  gems['puppet'] = ['~> 8.11', { require: false, source: 'https://rubygems-puppetcore.puppet.com' }]
+  gems['facter'] = ['~> 4.11', { require: false, source: 'https://rubygems-puppetcore.puppet.com' }]
+else
+  gems['puppet'] = location_for(puppet_version)
+  gems['facter'] = location_for(facter_version) if facter_version
+end
 
-# If facter or hiera versions have been specified via the environment
-# variables
-
-gems['facter'] = location_for(facter_version) if facter_version
 gems['hiera'] = location_for(hiera_version) if hiera_version
 
 gems.each do |gem_name, gem_params|

--- a/metadata.json
+++ b/metadata.json
@@ -67,7 +67,7 @@
   "requirements": [
     {
       "name": "puppet",
-      "version_requirement": ">= 7.0.0 < 9.0.0"
+      "version_requirement": ">= 8.0.0 < 9.0.0"
     }
   ],
   "pdk-version": "3.0.1",

--- a/spec/integration/puppetcore_spec.rb
+++ b/spec/integration/puppetcore_spec.rb
@@ -1,0 +1,39 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+require 'bundler'
+
+RSpec.describe 'Gemfile.lock verification' do
+  let(:parser) { Bundler::LockfileParser.new(Bundler.read_file(Bundler.default_lockfile)) }
+  let(:private_source) { 'https://rubygems-puppetcore.puppet.com/' }
+
+  # Helper method to get source remotes for a specific gem
+  def get_gem_source_remotes(gem_name)
+    spec = parser.specs.find { |s| s.name == gem_name }
+    return [] unless spec
+
+    source = spec.source
+    return [] unless source.is_a?(Bundler::Source::Rubygems)
+
+    source.remotes.map(&:to_s)
+  end
+
+  context 'when the environment is configured with a valid PUPPET_FORGE_TOKEN' do
+    it 'returns puppet from puppetcore' do
+      remotes = get_gem_source_remotes('puppet')
+      expect(remotes).to eq([private_source]),
+                         "Expected puppet to come from puppetcore, got: #{remotes.join(', ')}"
+    end
+
+    it 'returns facter from puppetcore' do
+      remotes = get_gem_source_remotes('facter')
+      expect(remotes).to eq([private_source]),
+                         "Expected facter to come from puppetcore, got: #{remotes.join(', ')}"
+    end
+
+    it 'has PUPPET_FORGE_TOKEN set' do
+      expect(ENV.fetch('PUPPET_FORGE_TOKEN', nil)).not_to be_nil,
+                                                          'Expected PUPPET_FORGE_TOKEN to be set'
+    end
+  end
+end


### PR DESCRIPTION
### Overview

This PR introduces puppetcore gem source integration to the provision module. When `PUPPET_FORGE_TOKEN` environment variable is set, the module will use authenticated puppetcore gem sources; otherwise, it will default to public gem sources. This implementation follows the "switch" design pattern to ensure all modules work correctly regardless of whether puppetcore is used or not.

### Changes

- `Gemfile`: Implemented conditional logic to use puppetcore gem source when `PUPPET_FORGE_TOKEN` is set
- `ci.yml` workflow: Updated to use Ruby 3.1+ which is required for puppetcore gems.  This workflow "uses" the shared cat-github-actions workflow that was updated in this PR: https://github.com/puppetlabs/cat-github-actions/pull/129
- `metadata.json`: Updated Puppet version requirement to 8.0.0+ to align with puppetcore
- `spec/integration/puppetcore_spec.rb`: Added integration tests to verify correct gem sources are used
