### PR TITLE
(CAT-2286) Remove puppet 7 infrastructure

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -5,7 +5,7 @@ require:
 AllCops:
   NewCops: enable
   DisplayCopNames: true
-  TargetRubyVersion: '2.6'
+  TargetRubyVersion: '3.1'
   Include:
   - "**/*.rb"
   Exclude:

--- a/Gemfile
+++ b/Gemfile
@@ -14,9 +14,6 @@ def location_for(place_or_version, fake_version = nil)
 end
 
 group :development do
-  gem "json", '= 2.1.0',                         require: false if Gem::Requirement.create(['>= 2.5.0', '< 2.7.0']).satisfied_by?(Gem::Version.new(RUBY_VERSION.dup))
-  gem "json", '= 2.3.0',                         require: false if Gem::Requirement.create(['>= 2.7.0', '< 3.0.0']).satisfied_by?(Gem::Version.new(RUBY_VERSION.dup))
-  gem "json", '= 2.5.1',                         require: false if Gem::Requirement.create(['>= 3.0.0', '< 3.0.5']).satisfied_by?(Gem::Version.new(RUBY_VERSION.dup))
   gem "json", '= 2.6.1',                         require: false if Gem::Requirement.create(['>= 3.1.0', '< 3.1.3']).satisfied_by?(Gem::Version.new(RUBY_VERSION.dup))
   gem "json", '= 2.6.3',                         require: false if Gem::Requirement.create(['>= 3.2.0', '< 4.0.0']).satisfied_by?(Gem::Version.new(RUBY_VERSION.dup))
   gem "racc", '~> 1.4.0',                        require: false if Gem::Requirement.create(['>= 2.7.0', '< 3.0.0']).satisfied_by?(Gem::Version.new(RUBY_VERSION.dup))

--- a/spec/tasks/lxd_spec.rb
+++ b/spec/tasks/lxd_spec.rb
@@ -92,7 +92,7 @@ describe 'provision::lxd' do
         },
         facts: {
           provisioner: 'lxd',
-          container_id: container_id,
+          container_id:,
           platform: lxd_platform
         }
       }

--- a/spec/tasks/vagrant_spec.rb
+++ b/spec/tasks/vagrant_spec.rb
@@ -13,12 +13,12 @@ describe 'vagrant' do
   before(:each) do
     # Stub $stdin.read to return a predefined JSON string
     allow($stdin).to receive(:read).and_return({
-      platform: platform,
+      platform:,
       action: 'provision',
       vars: 'role: worker1',
       inventory: tmpdir,
       enable_synced_folder: 'true',
-      provider: provider,
+      provider:,
       hyperv_vswitch: 'hyperv_vswitch',
       hyperv_smb_username: 'hyperv_smb_username'
     }.to_json)

--- a/tasks/lxd.rb
+++ b/tasks/lxd.rb
@@ -52,8 +52,8 @@ class LXDProvision
 
     facts = {
       provisioner: 'lxd',
-      container_id: container_id,
-      platform: platform
+      container_id:,
+      platform:
     }
 
     options.each do |option|
@@ -69,14 +69,14 @@ class LXDProvision
           'shell-command': 'sh -lc'
         }
       },
-      facts: facts
+      facts:
     }
 
     node[:vars] = vars unless vars.nil?
 
     inventory.add(node, 'lxd_nodes').save
 
-    { status: 'ok', node_name: container_id, node: node }
+    { status: 'ok', node_name: container_id, node: }
   end
 
   def tear_down

--- a/tasks/provision_service.rb
+++ b/tasks/provision_service.rb
@@ -19,9 +19,9 @@ class ProvisionService
   def platform_to_cloud_request_parameters(platform, cloud, region, zone)
     case platform
     when String
-      { cloud: cloud, region: region, zone: zone, images: [platform] }
+      { cloud:, region:, zone:, images: [platform] }
     when Array
-      { cloud: cloud, region: region, zone: zone, images: platform }
+      { cloud:, region:, zone:, images: platform }
     else
       platform[:cloud] = cloud unless cloud.nil?
       platform[:images] = [platform[:images]] if platform[:images].is_a?(String)
@@ -78,7 +78,7 @@ class ProvisionService
         body = response.body
         body_json = false
       end
-      puts({ _error: { kind: 'provision_service/service_error', msg: 'provision service returned an error', code: response.code, body: body, body_json: body_json } }.to_json)
+      puts({ _error: { kind: 'provision_service/service_error', msg: 'provision service returned an error', code: response.code, body:, body_json: } }.to_json)
       exit 1
     end
   end

--- a/tasks/update_node_pp.rb
+++ b/tasks/update_node_pp.rb
@@ -9,7 +9,7 @@ require 'puppet'
 def update_file(manifest, target_node)
   path = '/etc/puppetlabs/code/environments/production/manifests/nodes'
   _stdout, stderr, status = Open3.capture3("mkdir -p #{path}")
-  raise Puppet::Error, _("stderr: ' %{stderr}')" % { stderr: stderr }) if status != 0
+  raise Puppet::Error, _("stderr: ' %{stderr}')" % { stderr: }) if status != 0
 
   site_path = File.join(path, "#{target_node}.pp")
   if File.file?(site_path)

--- a/tasks/update_site_pp.rb
+++ b/tasks/update_site_pp.rb
@@ -8,7 +8,7 @@ require 'puppet'
 def update_file(manifest)
   path = '/etc/puppetlabs/code/environments/production/manifests'
   _stdout, stderr, status = Open3.capture3("mkdir -p #{path}")
-  raise Puppet::Error, "stderr: ' %{stderr}')" % { stderr: stderr } if status != 0
+  raise Puppet::Error, "stderr: ' %{stderr}')" % ({ stderr: }) if status != 0
 
   site_path = File.join(path, 'site.pp')
   File.open(site_path, 'w+') { |f| f.write(manifest) }

--- a/tasks/vagrant.rb
+++ b/tasks/vagrant.rb
@@ -85,7 +85,7 @@ def configure_remoting(platform, remoting_config_path, password)
     ssh_params = {
       port: remoting_config['port'],
       keys: remoting_config['identityfile'],
-      password: password,
+      password:,
       verbose: :debug
     }.compact
     Net::SSH.start(
@@ -192,7 +192,7 @@ def provision(platform, inventory, enable_synced_folder, provider, cpus, memory,
     node['vars'] = var_hash
   end
   inventory.add(node, group_name).save
-  { status: 'ok', node_name: node_name, node: node }
+  { status: 'ok', node_name:, node: }
 end
 
 def tear_down(node_name, inventory)


### PR DESCRIPTION
Puppet 7 is EOL. Therefore, we can remove the test infrastructure for it. This commit aims to clear up any testing/config infrastructure related to Puppet 7 and, by extension, Ruby 2.7. Bumping rubocop TargetRubyVersion to 3.1 and applying safe autocorrections.
