### PR TITLE
(MAINT): Update default URI in ProvisionService to a stable endpoint

### DIFF
--- a/spec/tasks/provision_service_spec.rb
+++ b/spec/tasks/provision_service_spec.rb
@@ -82,7 +82,7 @@ describe 'ProvisionService' do
 
     context 'when response is empty' do
       it 'return exception' do
-        stub_request(:post, 'https://facade-release-6f3kfepqcq-ew.a.run.app/v1/provision')
+        stub_request(:post, 'https://facade-maint-config-windows-use-ssh-6f3kfepqcq-ew.a.run.app/v1/provisionn')
           .with(
             body: '{"url":"https://api.github.com/repos/puppetlabs/puppetlabs-iis/actions/runs/1234567890","VMs":[{"cloud":null,"region":null,"zone":null,"images":["centos-8"]}]}',
             headers: {
@@ -100,7 +100,7 @@ describe 'ProvisionService' do
 
     context 'when successive retry success' do
       it 'return valid response' do
-        stub_request(:post, 'https://facade-release-6f3kfepqcq-ew.a.run.app/v1/provision')
+        stub_request(:post, 'https://facade-maint-config-windows-use-ssh-6f3kfepqcq-ew.a.run.app/v1/provisionn')
           .with(
             body: '{"url":"https://api.github.com/repos/puppetlabs/puppetlabs-iis/actions/runs/1234567890","VMs":[{"cloud":null,"region":null,"zone":null,"images":["centos-8"]}]}',
             headers: {
@@ -113,7 +113,7 @@ describe 'ProvisionService' do
           )
           .to_return(status: 200, body: '', headers: {})
         expect { provision_service.provision(platform, inventory, vars, retry_attempts) }.to raise_error(RuntimeError)
-        stub_request(:post, 'https://facade-release-6f3kfepqcq-ew.a.run.app/v1/provision')
+        stub_request(:post, 'https://facade-maint-config-windows-use-ssh-6f3kfepqcq-ew.a.run.app/v1/provisionn')
           .with(
             body: '{"url":"https://api.github.com/repos/puppetlabs/puppetlabs-iis/actions/runs/1234567890","VMs":[{"cloud":null,"region":null,"zone":null,"images":["centos-8"]}]}',
             headers: {
@@ -132,7 +132,7 @@ describe 'ProvisionService' do
 
     context 'when response is valid' do
       it 'return valid response' do
-        stub_request(:post, 'https://facade-release-6f3kfepqcq-ew.a.run.app/v1/provision')
+        stub_request(:post, 'https://facade-maint-config-windows-use-ssh-6f3kfepqcq-ew.a.run.app/v1/provisionn')
           .with(
             body: '{"url":"https://api.github.com/repos/puppetlabs/puppetlabs-iis/actions/runs/1234567890","VMs":[{"cloud":null,"region":null,"zone":null,"images":["centos-8"]}]}',
             headers: {

--- a/tasks/provision_service.rb
+++ b/tasks/provision_service.rb
@@ -13,7 +13,9 @@ class ProvisionService
   RETRY_COUNT = 3
 
   def default_uri
-    'https://facade-release-6f3kfepqcq-ew.a.run.app/v1/provision'
+    # 'https://facade-release-6f3kfepqcq-ew.a.run.app/v1/provision'
+    # NOTE: Setting below URL as default until above URL is stable
+    'https://facade-maint-config-windows-use-ssh-6f3kfepqcq-ew.a.run.app/v1/provision'
   end
 
   def platform_to_cloud_request_parameters(platform, cloud, region, zone)


### PR DESCRIPTION
## Summary
Update default URI in ProvisionService to a stable endpoint

## Additional Context
The default URL used for provisioning VMs is currently not working, so this change is necessary to ensure the CI workflow remains functional.

## Checklist
- [ ] 🟢 Spec tests.
- [ ] 🟢 Acceptance tests.
- [ ] Manually verified.
