### PR TITLE
PA-7893 Update puppetserver package fetching urls

### DIFF
--- a/tasks/install_puppetserver.sh
+++ b/tasks/install_puppetserver.sh
@@ -144,9 +144,7 @@ fi
 osname=$(parse_platform "$platform" "osname")
 major_version=$(parse_platform "$platform" "majorversion")
 osfamily=$(fetch_osfamily "$osname")
-# Keep the full collection name (e.g., puppet8-nightly) instead of truncating
-# collection=$(fetch_collection "$collection")
-collection=$collection
+collection=$(fetch_collection "$collection")
 
 if [[ "$collection" == "puppet5" ]]; then
   echo "puppet5 eol!"

--- a/tasks/install_puppetserver.sh
+++ b/tasks/install_puppetserver.sh
@@ -59,12 +59,17 @@ fetch_osfamily() {
 }
 
 fetch_collection() {
-  myarr=()
-  for x in $(echo "$1" | tr "-" "\n")
-  do
-    myarr+=("$x")
-  done
-  echo "${myarr[0]}"
+  # Handle puppetcore8-nightly -> puppet8-nightly conversion
+  if [[ "$1" == puppetcore8* ]]; then
+    echo "${1/puppetcore8/puppet8}"
+  else
+    myarr=()
+    for x in $(echo "$1" | tr "-" "\n")
+    do
+      myarr+=("$x")
+    done
+    echo "${myarr[0]}"
+  fi
 }
 
 fetch_codename() {

--- a/tasks/install_puppetserver.sh
+++ b/tasks/install_puppetserver.sh
@@ -139,7 +139,9 @@ fi
 osname=$(parse_platform "$platform" "osname")
 major_version=$(parse_platform "$platform" "majorversion")
 osfamily=$(fetch_osfamily "$osname")
-collection=$(fetch_collection "$collection")
+# Keep the full collection name (e.g., puppet8-nightly) instead of truncating
+# collection=$(fetch_collection "$collection")
+collection=$collection
 
 if [[ "$collection" == "puppet5" ]]; then
   echo "puppet5 eol!"

--- a/tasks/install_puppetserver.sh
+++ b/tasks/install_puppetserver.sh
@@ -157,7 +157,7 @@ if [[ "$osfamily" == "debian" ]]; then
     echo "No builds for $platform"
     exit 1
   else
-    run_cmd "curl -o puppet.deb http://apt.puppetlabs.com/${collection}-release-${codename}.deb"
+    run_cmd "curl -o puppet.deb https://artifactory.delivery.puppetlabs.net:443/artifactory/internal_nightly__local/apt/${collection}-release-${codename}.deb"
     dpkg -i --force-confmiss puppet.deb
     apt-get update -y
     apt-get install puppetserver -y
@@ -165,7 +165,7 @@ if [[ "$osfamily" == "debian" ]]; then
 fi
 
 if [[ "$osfamily" == "redhat" ]]; then
-  run_cmd "curl -o puppet.rpm http://yum.puppetlabs.com/${collection}-release-el-${major_version}.noarch.rpm"
+  run_cmd "curl -o puppet.rpm https://artifactory.delivery.puppetlabs.net:443/artifactory/internal_nightly__local/yum/${collection}-release-el-${major_version}.noarch.rpm"
   rpm -Uvh puppet.rpm --quiet
   yum install puppetserver -y --quiet
 fi


### PR DESCRIPTION
## Summary
Updating apt base URLs to artifactory while fetching puppetserver packages. 
-> While removing support for puppet 7 in puppetlabs-kubernetes, the collection specified as 'puppetcore8-nightly' was not being fetched as a valid puppetserver name.


## Checklist
- [x] 🟢 Spec tests