### PR TITLE
(CAT-2590) Prepare for Puppetcore 9

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,5 +12,5 @@ jobs:
     with:
       # This line enables shellcheck to be run on this repository
       run_shellcheck: true
-      ruby_version: '3.1'
+      ruby_version: '3.2'
     secrets: "inherit"

--- a/.github/workflows/mend.yml
+++ b/.github/workflows/mend.yml
@@ -12,4 +12,6 @@ jobs:
 
   mend:
     uses: "puppetlabs/cat-github-actions/.github/workflows/tooling_mend_ruby.yml@main"
+    with:
+      ruby_version: '3.2'
     secrets: "inherit"

--- a/Gemfile
+++ b/Gemfile
@@ -17,7 +17,7 @@ group :development do
   gem "json", '= 2.6.1',                         require: false if Gem::Requirement.create(['>= 3.1.0', '< 3.1.3']).satisfied_by?(Gem::Version.new(RUBY_VERSION.dup))
   gem "json", '= 2.6.3',                         require: false if Gem::Requirement.create(['>= 3.2.0', '< 4.0.0']).satisfied_by?(Gem::Version.new(RUBY_VERSION.dup))
   gem "racc", '~> 1.4.0',                        require: false if Gem::Requirement.create(['>= 2.7.0', '< 3.0.0']).satisfied_by?(Gem::Version.new(RUBY_VERSION.dup))
-  gem "voxpupuli-puppet-lint-plugins", '~> 5.0', require: false
+  gem "voxpupuli-puppet-lint-plugins", '~> 7.0', require: false
   gem "facterdb", '~> 1.18',                     require: false
   gem "metadata-json-lint", '~> 4.0',            require: false
   gem "puppetlabs_spec_helper", '~> 6.0',        require: false

--- a/Gemfile
+++ b/Gemfile
@@ -1,6 +1,6 @@
 source ENV['GEM_SOURCE'] || 'https://rubygems.org'
 
-def location_for(place_or_version, fake_version = nil)
+def location_for(place_or_version, fake_version = nil, opts = {})
   git_url_regex = %r{\A(?<url>(https?|git)[:@][^#]*)(#(?<branch>.*))?}
   file_url_regex = %r{\Afile:\/\/(?<path>.*)}
 
@@ -9,7 +9,7 @@ def location_for(place_or_version, fake_version = nil)
   elsif place_or_version && (file_url = place_or_version.match(file_url_regex))
     ['>= 0', { path: File.expand_path(file_url[:path]), require: false }]
   else
-    [place_or_version, { require: false }]
+    [place_or_version, { require: false }.merge(opts)]
   end
 end
 
@@ -54,15 +54,18 @@ puppet_version = ENV.fetch('PUPPET_GEM_VERSION', nil)
 facter_version = ENV.fetch('FACTER_GEM_VERSION', nil)
 hiera_version = ENV.fetch('HIERA_GEM_VERSION', nil)
 
-# If PUPPET_FORGE_TOKEN is set then use authenticated source for both puppet and facter, since facter is a transitive dependency of puppet
-# Otherwise, do as before and use location_for to fetch gems from the default source
-if !ENV['PUPPET_FORGE_TOKEN'].to_s.empty?
-  gems['puppet'] = ['~> 8.11', { require: false, source: 'https://rubygems-puppetcore.puppet.com' }]
-  gems['facter'] = ['~> 4.11', { require: false, source: 'https://rubygems-puppetcore.puppet.com' }]
-else
-  gems['puppet'] = location_for(puppet_version)
-  gems['facter'] = location_for(facter_version) if facter_version
-end
+# If PUPPET_FORGE_TOKEN(_PUBLIC) is set then use the authenticated puppetcore source for both
+# puppet and facter, since facter is a transitive dependency of puppet. Still respects
+# PUPPET_GEM_VERSION/FACTER_GEM_VERSION (e.g. a '~> 9.0' CI lane) rather than pinning a fixed
+# version, so this doesn't silently keep testing 8.x once a forge token is present.
+puppetcore_opts = if !(ENV['PUPPET_FORGE_TOKEN_PUBLIC'] || ENV['PUPPET_FORGE_TOKEN']).to_s.empty?
+                    { source: 'https://rubygems-puppetcore.puppet.com' }
+                  else
+                    {}
+                  end
+
+gems['puppet'] = location_for(puppet_version, nil, puppetcore_opts)
+gems['facter'] = location_for(facter_version, nil, puppetcore_opts) if facter_version
 
 gems['hiera'] = location_for(hiera_version) if hiera_version
 

--- a/Gemfile
+++ b/Gemfile
@@ -20,13 +20,12 @@ group :development do
   gem "voxpupuli-puppet-lint-plugins", '~> 7.0', require: false
   gem "facterdb", '~> 1.18',                     require: false
   gem "metadata-json-lint", '~> 4.0',            require: false
-  gem "puppetlabs_spec_helper", '~> 6.0',        require: false
+  gem "puppetlabs_spec_helper", '~> 9.0',        require: false
   gem "rspec-puppet-facts", '~> 2.0',            require: false
   gem "dependency_checker", '~> 1.0.0',          require: false
   gem "parallel_tests", '= 3.12.1',              require: false
   gem "pry", '~> 0.10',                          require: false
   gem "simplecov-console", '~> 0.9',             require: false
-  gem "codecov", '~> 0.6',                       require: false
   gem "puppet-debugger", '~> 1.0',               require: false
   gem "rubocop", '~> 1.50.0',                    require: false
   gem "rubocop-performance", '= 1.16.0',         require: false
@@ -42,7 +41,7 @@ group :system_tests do
 end
 group :release_prep do
   gem "puppet-strings", '~> 4.0',         require: false
-  gem "puppetlabs_spec_helper", '~> 6.0', require: false
+  gem "puppetlabs_spec_helper", '~> 9.0', require: false
 end
 
 puppet_version = ENV['PUPPET_GEM_VERSION']

--- a/Gemfile
+++ b/Gemfile
@@ -50,20 +50,19 @@ facter_version = ENV['FACTER_GEM_VERSION']
 hiera_version = ENV['HIERA_GEM_VERSION']
 
 gems = {}
+bolt_version = ENV.fetch('BOLT_GEM_VERSION', nil)
 puppet_version = ENV.fetch('PUPPET_GEM_VERSION', nil)
 facter_version = ENV.fetch('FACTER_GEM_VERSION', nil)
 hiera_version = ENV.fetch('HIERA_GEM_VERSION', nil)
 
-# If PUPPET_FORGE_TOKEN(_PUBLIC) is set then use the authenticated puppetcore source for both
-# puppet and facter, since facter is a transitive dependency of puppet. Still respects
-# PUPPET_GEM_VERSION/FACTER_GEM_VERSION (e.g. a '~> 9.0' CI lane) rather than pinning a fixed
-# version, so this doesn't silently keep testing 8.x once a forge token is present.
+# Use the authenticated puppetcore source for bolt/puppet/facter when a forge token is present.
 puppetcore_opts = if !(ENV['PUPPET_FORGE_TOKEN_PUBLIC'] || ENV['PUPPET_FORGE_TOKEN']).to_s.empty?
                     { source: 'https://rubygems-puppetcore.puppet.com' }
                   else
                     {}
                   end
 
+gems['bolt'] = location_for(bolt_version, nil, puppetcore_opts)
 gems['puppet'] = location_for(puppet_version, nil, puppetcore_opts)
 gems['facter'] = location_for(facter_version, nil, puppetcore_opts) if facter_version
 

--- a/Gemfile
+++ b/Gemfile
@@ -37,7 +37,7 @@ group :development do
   gem "webmock",                                 require: false
 end
 group :system_tests do
-  gem "puppet_litmus", '~> 1.0', require: false, platforms: [:ruby, :x64_mingw]
+  gem "puppet_litmus", '>= 2.0', require: false, platforms: [:ruby, :x64_mingw]
   gem "serverspec", '~> 2.41',   require: false
 end
 group :release_prep do

--- a/Rakefile
+++ b/Rakefile
@@ -3,7 +3,7 @@
 require 'bundler'
 require 'puppet_litmus/rake_tasks' if Gem.loaded_specs.key? 'puppet_litmus'
 require 'puppetlabs_spec_helper/rake_tasks'
-require 'puppet-syntax/tasks/puppet-syntax'
+require 'puppetlabs-syntax/tasks/puppetlabs-syntax'
 require 'puppet-strings/tasks' if Gem.loaded_specs.key? 'puppet-strings'
 
 PuppetLint.configuration.send('disable_relative')

--- a/metadata.json
+++ b/metadata.json
@@ -67,7 +67,7 @@
   "requirements": [
     {
       "name": "puppet",
-      "version_requirement": ">= 8.0.0 < 9.0.0"
+      "version_requirement": ">= 8.0.0 < 10.0.0"
     }
   ],
   "pdk-version": "3.0.1",


### PR DESCRIPTION
With the arrival of Puppetcore 9, we need to ensure that our tools are compatible with Ruby 4.

- The Gemfile's `PUPPET_FORGE_TOKEN` puppetcore-source branch was hardcoded to `puppet ~> 8.11` / `facter ~> 4.11`, so it would keep testing 8.x indefinitely even once a Puppet 9 lane exists. This now respects `PUPPET_GEM_VERSION`/`FACTER_GEM_VERSION` (set per-lane by the shared `module_ci.yml` matrix) instead of a fixed pin, and also checks `PUPPET_FORGE_TOKEN_PUBLIC` (the secret name actually used in this repo) alongside `PUPPET_FORGE_TOKEN`.
- Raised the puppet version upper bound in `metadata.json` from `< 9.0.0` to `< 10.0.0` so `matrix_from_metadata_v3` picks up a Puppet 9 test lane.

Same initiative as [rspec-puppet#136](https://github.com/puppetlabs/rspec-puppet/pull/136), adapted to this module's existing Gemfile pattern.

## Checklist
- [x] 🟢 Spec tests.
- [ ] Manually verified.