### PR TITLE
Add missing codecov gem to unblock SimpleCov coverage reporting

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -26,6 +26,7 @@ group :development do
   gem "parallel_tests", '= 3.12.1',              require: false
   gem "pry", '~> 0.10',                          require: false
   gem "simplecov-console", '~> 0.9',             require: false
+  gem "codecov", '~> 0.6',                       require: false
   gem "puppet-debugger", '~> 1.0',               require: false
   gem "rubocop", '~> 1.50.0',                    require: false
   gem "rubocop-performance", '= 1.16.0',         require: false


### PR DESCRIPTION
## Summary
`spec_helper.rb`'s `SIMPLECOV=yes` gate (via `puppetlabs_spec_helper`'s `module_spec_helper`) requires `simplecov`, `simplecov-console`, and `codecov` to all be loadable. `simplecov-console` was already declared in the Gemfile and `simplecov` was present only transitively, but `codecov` was missing entirely. This PR adds `gem "codecov", '~> 0.6', require: false` to the Gemfile's `:development` group — no other changes.

## Additional Context
- [x] Root cause and the steps to reproduce: running `SIMPLECOV=yes bundle exec rake spec` on `main` raises `LoadError: cannot load such file -- codecov` at `spec_helper.rb:7`, which `puppetlabs_spec_helper` wraps into a generic "add the simplecov, simplecov-console, codecov gems to Gemfile" error. Surfaced during a DevX coverage audit across PDK/Bolt-adjacent tooling (PPM-1579).
- [x] Thought process: `codecov` is required by the existing gate but was never added as a dependency — this just supplies the missing piece rather than changing any gating behavior.

## Related Issues (if any)
Surfaced as part of PPM-1579 (Quality Improvements for H2 2026) coverage audit — no existing issue filed against this repo specifically.

## Checklist
- [x] 🟢 Spec tests. — `SIMPLECOV=yes bundle exec rake spec` now completes and reports 82.02% line coverage (406/495) instead of erroring. Note: 3 pre-existing failures in `spec/integration/puppetcore_spec.rb` (missing `PUPPET_FORGE_TOKEN` env var) are unrelated to this change.
- [ ] 🟢 Acceptance tests. — not run (this is a dev/coverage-tooling-only dependency change, no acceptance-test surface affected).
- [x] Manually verified. — verified locally under Ruby 3.3.11; note CI runs Ruby 3.1 (`ci.yml`), not independently verified against 3.1 but this is a pure Gemfile dependency addition with no version-specific code.
