### PR TITLE
(maint) Handle puppetcore9-nightly -> puppet9-nightly collection conversion

### DIFF
--- a/tasks/install_puppetserver.sh
+++ b/tasks/install_puppetserver.sh
@@ -62,6 +62,9 @@ fetch_collection() {
   # Handle puppetcore8-nightly -> puppet8-nightly conversion
   if [[ "$1" == puppetcore8* ]]; then
     echo "${1/puppetcore8/puppet8}"
+  # Handle puppetcore9-nightly -> puppet9-nightly conversion
+  elif [[ "$1" == puppetcore9* ]]; then
+    echo "${1/puppetcore9/puppet9}"
   else
     myarr=()
     for x in $(echo "$1" | tr "-" "\n")


### PR DESCRIPTION
## Summary

`fetch_collection()` in `tasks/install_puppetserver.sh` only special-cases `puppetcore8-nightly` → `puppet8-nightly` (added in #289 / PA-7893 for the same class of bug). For `puppetcore9-nightly` it falls through to the generic branch and returns the collection unchanged (`puppetcore9`), so the script requests a nonexistent nightly repo RPM (`puppetcore9-release-el-<N>.noarch.rpm` instead of `puppet9-release-el-<N>.noarch.rpm`).

Since the script never checks the `curl`/`rpm` exit codes and unconditionally `exit 0`s, this fails silently: `yum install puppetserver` finds no package in any configured repo, but the Bolt task/plan still reports success.

Fix mirrors the existing `puppetcore8` handling:
```bash
elif [[ "$1" == puppetcore9* ]]; then
  echo "${1/puppetcore9/puppet9}"
```

## How this was found

Surfaced via puppetlabs-kubernetes#723 (MODULES-11735, Puppet 9 support). The `Integration (rhel-8, puppetcore9-nightly)` job failed much later, in an RSpec `before(:suite)` hook:
```
Failure/Error: run_shell('systemctl start puppetserver')
RuntimeError:
  ...stderr=>"Failed to start puppetserver.service: Unit puppetserver.service not found.\n"
```
`litmus:install_agent[puppetcore9-nightly]` (a few steps earlier, same job) succeeded — it goes through `puppet_litmus`'s own, separately-maintained collection resolution, which already understands `puppetcore9-nightly`. Only this task's `fetch_collection()` was missing the update.

Verified the fix locally by extracting `fetch_collection()` and running it against `puppetcore8-nightly`, `puppetcore9-nightly`, and unrelated values (`puppet7-nightly`, `puppetcore8-release`) — only the intended conversion changes.

## Test plan
- [x] Local shell logic verification (see above)
- [ ] CI

🤖 Generated with [Claude Code](https://claude.com/claude-code)